### PR TITLE
fix: extends from Reference instead of Node to prevent memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
 
+## 1.0.1 (2021-05-09)
+
+### Fixed
+
+- Extend scripts from `Reference` instead of `Node` to prevent memory leaks.
+
+### Thanks
+
+Thanks to Enes Yesilyurt (@Tols-Toy) for spotting the memory leak and for suggesting a fix for it.
+
 ## 1.0.0 (2021-02-18)
 
 Initial release

--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 const Interpreter = preload('./interpreter/Interpreter.gd')
 

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 signal variable_changed(name, value, previous_value)
 signal event_triggered(event_name)

--- a/addons/clyde/interpreter/LogicInterpreter.gd
+++ b/addons/clyde/interpreter/LogicInterpreter.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 const SPECIAL_VARIABLE_NAMES = [ 'OPTIONS_COUNT' ];
 

--- a/addons/clyde/interpreter/Memory.gd
+++ b/addons/clyde/interpreter/Memory.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 signal variable_changed(name, value, previous_value)
 

--- a/addons/clyde/parser/Lexer.gd
+++ b/addons/clyde/parser/Lexer.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 const TOKEN_TEXT = "TEXT"
 const TOKEN_INDENT = "INDENT"

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 const Lexer = preload("./Lexer.gd")
 const TokenWalker = preload("./TokenWalker.gd")

--- a/addons/clyde/parser/TokenWalker.gd
+++ b/addons/clyde/parser/TokenWalker.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 const Lexer = preload('./Lexer.gd')
 

--- a/addons/clyde/plugin.cfg
+++ b/addons/clyde/plugin.cfg
@@ -3,5 +3,5 @@
 name="Clyde Dialogue"
 description="Interpreter and importer for Clyde Dialogue Language"
 author="Vinicius Gerevini"
-version="1.0.0"
+version="1.0.1"
 script="plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Node",
+"base": "Reference",
 "class": "ClydeDialogue",
 "language": "GDScript",
 "path": "res://addons/clyde/ClydeDialogue.gd"


### PR DESCRIPTION
As pointed out on issue #1, extending from `Node` in scripts that are not attached to a scene tree may cause memory leaks, as those nodes are required to be freed explicitly.
I'm changing all scripts to extend from `Reference` instead, which are freed as soon there are no more references to the object.

See https://docs.godotengine.org/en/stable/getting_started/workflow/best_practices/node_alternatives.html