### PR TITLE
fix options and variations after loading previously stringified object

### DIFF
--- a/addons/clyde/interpreter/Memory.gd
+++ b/addons/clyde/interpreter/Memory.gd
@@ -11,11 +11,11 @@ var _mem = {
 }
 
 func set_as_accessed(id):
-	_mem.access[id] = true
+	_mem.access[str(id)] = true
 
 
 func was_already_accessed(id):
-	return _mem.access.has(id)
+	return _mem.access.has(str(id))
 
 
 func get_variable(id, default_value = null):

--- a/addons/clyde/interpreter/Memory.gd
+++ b/addons/clyde/interpreter/Memory.gd
@@ -35,12 +35,12 @@ func set_variable(id, value):
 
 
 func set_internal_variable(id, value):
-	_mem.internal[id] = value
+	_mem.internal[str(id)] = value
 	return value
 
 
 func get_internal_variable(id, default_value):
-	var value = _mem.internal.get(id);
+	var value = _mem.internal.get(str(id));
 	if value == null:
 		return default_value;
 	return value

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -37,6 +37,13 @@ func _option(option):
 	}
 
 
+func _get_next_options_content(dialogue):
+	var content = dialogue.get_content()
+	while content.type != "options":
+		content = dialogue.get_content()
+	return content
+
+
 func test_simple_lines_file():
 	var dialogue = ClydeDialogue.new()
 	dialogue.load_dialogue('simple_lines')
@@ -97,6 +104,7 @@ func test_options():
 	for line in life_option:
 		assert_eq_deep(dialogue.get_content(), line)
 
+
 func test_fallback_options():
 	var interpreter = ClydeDialogue.Interpreter.new()
 	var content = parse("* a\n> b\nend")
@@ -108,6 +116,7 @@ func test_fallback_options():
 	assert_eq_deep(interpreter.get_content().text, "end")
 	interpreter.select_block()
 	assert_eq_deep(interpreter.get_content(), _line({ "type": "line", "text": "b" }))
+
 
 func test_blocks_and_diverts():
 	var dialogue = ClydeDialogue.new()
@@ -250,6 +259,7 @@ func test_logic():
 	assert_eq_deep(dialogue.get_content().text, "inside a condition")
 	assert_eq_deep(dialogue.get_content(), null)
 
+
 func test_variables():
 	var dialogue = ClydeDialogue.new()
 	dialogue.load_dialogue('variables')
@@ -270,6 +280,7 @@ func test_variables():
 	assert_eq_deep(dialogue.get_content(), _line({ "type": "line", "text": "I'm in trouble" }))
 	assert_eq_deep(dialogue.get_content(), null)
 	assert_eq_deep(dialogue.get_variable('xx'), true)
+
 
 func test_set_variables():
 	var dialogue = ClydeDialogue.new()
@@ -297,6 +308,30 @@ func test_data_control():
 	dialogue.clear_data()
 	dialogue.start()
 	assert_eq_deep(dialogue.get_content().text, "Hello")
+
+
+func test_persisted_data_control_options():
+	var dialogue = ClydeDialogue.new()
+	dialogue.load_dialogue('options')
+
+	var content = _get_next_options_content(dialogue)
+	assert_eq(content.options.size(), 3)
+
+	dialogue.choose(0)
+	dialogue.start()
+
+	content = _get_next_options_content(dialogue)
+	assert_eq(content.options.size(), 2)
+
+	var stringified_data = to_json(dialogue.get_data())
+
+	var dialogue2 = ClydeDialogue.new()
+	dialogue2.load_dialogue('options')
+	dialogue2.load_data(parse_json(stringified_data))
+
+	var content2 = _get_next_options_content(dialogue)
+	assert_eq(content2.options.size(), 2)
+	assert_eq_deep(content2, content)
 
 
 var pending_events = []

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -334,6 +334,23 @@ func test_persisted_data_control_options():
 	assert_eq_deep(content2, content)
 
 
+func test_persisted_data_control_variations():
+	var dialogue = ClydeDialogue.new()
+	dialogue.load_dialogue('variations')
+
+	assert_eq_deep(dialogue.get_content().text, "Hello")
+	dialogue.start()
+	assert_eq_deep(dialogue.get_content().text, "Hi")
+
+	var dialogue2 = ClydeDialogue.new()
+	dialogue2.load_dialogue('variations')
+
+	var stringified_data = to_json(dialogue.get_data())
+
+	dialogue2.load_data(parse_json(stringified_data))
+	assert_eq_deep(dialogue2.get_content().text, "Hey")
+
+
 var pending_events = []
 
 func test_events():


### PR DESCRIPTION
Solves #12 

As reported in the issue, when loading previously persisted dialogue internal data, options that where not supposed to be visible are returned. This is due to objects allowing numbers as keys, while JSON (the format usually used for persistence) not.

This also affects variations and external variables.

I'm fixing options and variations in this PR.

For external variables I'll enforce String type for variable names in the next major version. What this means is that for the time being if saving a variable with a number as name `dialogue.set_variable(1, "blah")`, the only way to get it back after saving is by using a string `dialogue.get_variable("1")`.