### PR TITLE
fix boolean assignment shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+## Fixed
+
+- Standalone `{set a}` would pass parser, but break on interpreter. Now, this is equivalent to `{ set a = true }`.
+
 ## 3.0.0 (2021-11-22)
 
 ### Breaking Changes

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -570,6 +570,15 @@ func _condition():
 
 
 func _assignment_expression():
+	var assignment = _assignment_expression_internal()
+
+	if assignment.type == "variable":
+		return AssignmentNode(assignment, _assignment_operators[Lexer.TOKEN_ASSIGN], BooleanLiteralNode('true'))
+	else:
+		return assignment
+
+
+func _assignment_expression_internal():
 	_tokens.consume([Lexer.TOKEN_IDENTIFIER])
 	var variable = VariableNode(_tokens.current_token.value)
 
@@ -581,7 +590,7 @@ func _assignment_expression():
 	_tokens.consume(operators)
 
 	if _tokens.peek([Lexer.TOKEN_IDENTIFIER]) && _tokens.peek(operators + [Lexer.TOKEN_BRACE_CLOSE], 1):
-		return AssignmentNode(variable, _assignment_operators[_tokens.current_token.token], _assignment_expression())
+		return AssignmentNode(variable, _assignment_operators[_tokens.current_token.token], _assignment_expression_internal())
 	return AssignmentNode(variable, _assignment_operators[_tokens.current_token.token], _expression())
 
 

--- a/test/test_parser_logic.gd
+++ b/test/test_parser_logic.gd
@@ -907,6 +907,25 @@ func test_divert_with_assignment():
 	assert_eq_deep(result, expected)
 
 
+func test_standalone_assignment_with_standalone_variable():
+	var result = parse("{ set a }")
+
+	var expected = _create_doc_payload([
+		{
+			"type": "assignments",
+			"assignments": [
+				{
+					"type": "assignment",
+					"variable": { "type": "variable", "name": "a", },
+					"operation": "assign",
+					"value": { "type": "literal", "name": "boolean", "value": true, },
+				},
+			],
+		},
+	])
+	assert_eq_deep(result, expected)
+
+
 func test_trigger_event():
 	var result = parse("{ trigger some_event } trigger")
 	var expected = _create_doc_payload([{


### PR DESCRIPTION
Support `{ set variable_name }`. This was valid during parsing, but it would break in runtime.

Now, this is equivalent to `{ set variable_name = true }`.