### PR TITLE
Return "end" object on dialogue end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Increment assigment now have default values. i.e. If you run `set a += 1` when `a` is not set, it will be set to 1. Before it would break because value was null.
     - As `+` is also used for strings, this `set a += "abc"` also works.
+- Return end object (`{ "type": "end" }`) instead of null on dialogue end.
 
 ### Fixed
 

--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -92,7 +92,7 @@ func _load_file(path) -> Dictionary:
 	if parse_error != OK or typeof(json_file.data) != TYPE_DICTIONARY:
 		printerr("Failed to parse file: ", json_file.get_error_message())
 		return {}
-	
+
 	return json_file.data
 
 

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -145,6 +145,8 @@ func _handle_document_node(_node):
 		node.content_index = content_index
 		return _handle_next_node(node.current.content[content_index]);
 
+	return { "type": "end" }
+
 
 func _handle_content_node(content_node):
 	if content_node.get("_index") == null:
@@ -296,6 +298,8 @@ func _handle_block_node(block):
 		node.content_index = content_index
 		return _handle_next_node(node.current.content.content[content_index]);
 
+	return { "type": "end" }
+
 
 func _handle_divert_node(divert):
 	if divert.target == '<parent>':
@@ -307,11 +311,15 @@ func _handle_divert_node(divert):
 		if _stack.size() > 1:
 			_stack_pop()
 			return _handle_next_node(_stack_head().current)
-	elif divert.target == '<end>':
+
+		return { "type": "end" }
+
+	if divert.target == '<end>':
 		_initialise_stack(_doc)
 		_stack_head().content_index = _stack_head().current.content.size();
-	else:
-		return _handle_next_node(_anchors[divert.target])
+		return { "type": "end" }
+
+	return _handle_next_node(_anchors[divert.target])
 
 
 func _handle_assignments_node(assignment_node):

--- a/example/example.gd
+++ b/example/example.gd
@@ -12,7 +12,7 @@ func _ready():
 
 func _get_next_dialogue_line():
 	var content = _dialogue.get_content()
-	if content == null:
+	if content.type == "end":
 		$line.hide()
 		$options.hide()
 		$dialogue_ended.show()

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -247,7 +247,7 @@ func test_blocks_and_diverts():
 
 	var goodbye_option = [
 		_line({ "type": "line", "text": "See you next time!", "speaker": "player" }),
-		null
+		{ "type": "end" },
 	]
 
 	for line in initial_dialogue:
@@ -355,7 +355,7 @@ func test_logic():
 	assert_eq_deep(dialogue.get_content().text, "variable remains as 3 when init assign")
 	assert_eq_deep(dialogue.get_content().text, "This is a block")
 	assert_eq_deep(dialogue.get_content().text, "inside a condition")
-	assert_eq_deep(dialogue.get_content(), null)
+	assert_eq_deep(dialogue.get_content().type, "end")
 
 
 func test_assigments():
@@ -377,7 +377,7 @@ func test_assigments():
 	assert_eq_deep(interpreter.get_content().text, 'this should be 1')
 	assert_eq_deep(interpreter.get_content().text, 'this should be 4')
 	assert_eq_deep(interpreter.get_content().text, 'this should be abcdef')
-	assert_eq_deep(interpreter.get_content(), null)
+	assert_eq_deep(interpreter.get_content().type, "end")
 
 
 func test_uninitialized_increment_assigment():
@@ -399,7 +399,7 @@ func test_uninitialized_increment_assigment():
 	assert_eq_deep(interpreter.get_content().text, 'this should be 0')
 	assert_eq_deep(interpreter.get_content().text, 'this should be 0')
 	assert_eq_deep(interpreter.get_content().text, 'this should be b')
-	assert_eq_deep(interpreter.get_content(), null)
+	assert_eq_deep(interpreter.get_content().type, "end")
 
 
 func test_variables():
@@ -420,7 +420,7 @@ func test_variables():
 	assert_eq_deep(dialogue.get_content(), _line({ "type": "line", "text": "I want to talk about the universe!", "speaker": "player" }))
 	assert_eq_deep(dialogue.get_content(), _line({ "type": "line", "text": "That's too complex!", "speaker": "npc" }))
 	assert_eq_deep(dialogue.get_content(), _line({ "type": "line", "text": "I'm in trouble" }))
-	assert_eq_deep(dialogue.get_content(), null)
+	assert_eq_deep(dialogue.get_content().type, "end")
 	assert_eq_deep(dialogue.get_variable('xx'), true)
 
 
@@ -525,9 +525,9 @@ func test_events():
 
 	while true:
 		var res = dialogue.get_content()
-		if res == null:
+		if res.type == "end":
 			break;
-		if res.type == 'options':
+		if res.type == "options":
 			dialogue.choose(0)
 
 	assert_eq(pending_events.size(), 0)


### PR DESCRIPTION
this is a breaking change. Prevent issues with null checks.

Related #20 