### PR TITLE
Include hidden options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Breaking changes
+
+Dialogues now return an object when ended.
+
 ### Added
 
 - Assignment initializer operator `?=`. It only assigns if variable was not set before.
@@ -17,6 +21,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Use correct `fmod` for `a %=` operations.
+- Fixed crash when exiting editor started via command line (@Rubonnek)
+
+### Thanks
+
+- Thanks to @Rubonnek for finding and fixing the exit crash.
+- Thanks to @ThePat02 for updating the doc comments to be Godot 4's doc comments.
 
 ## 3.2.1 (2023-09-07)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -60,6 +60,12 @@ func load_data(data)
 # Clear all internal data
 func clear_data()
 
+# Set optional settings for current interpreter. [br]
+# Options:
+#   include_hidden_options (boolean, default false): Returns conditional options event when check resulted in false.
+#
+func configure(options)
+
 ```
 
 ### Creating an object
@@ -145,10 +151,13 @@ Options list with options/topics the player may choose from (`Dictionary`).
 }
 ```
 
-#### Null
+#### End
 
-If `dialogue.get_content()` returns `Null`, it means the dialogue reached an end.
+Returned when the dialogue reached its end. Any new subsequent call will return an end object.
 
+```gdscript
+{ "type": "end" }
+```
 
 ### Listening to variable changes
 

--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -30,7 +30,7 @@ var _interpreter
 
 ## Set optional settings for current interpreter. [br]
 ## Options:
-##   include_hidden_options (boolean, default false): Returns conditional options that failed the check.
+##   include_hidden_options (boolean, default false): Returns conditional options even when check resulted in false.
 ##
 func configure(options):
 	_options = options

--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -24,8 +24,16 @@ signal event_triggered(name)
 ## By default, it loads from ProjectSettings dialogue/source_folder
 var dialogue_folder = null
 
-
+var _options = {}
 var _interpreter
+
+
+## Set optional settings for current interpreter. [br]
+## Options:
+##   include_hidden_options (boolean, default false): Returns conditional options that failed the check.
+##
+func configure(options):
+	_options = options
 
 
 ## Load dialogue file. [br]
@@ -40,6 +48,7 @@ func load_dialogue(file_name, block = null):
 	_interpreter = Interpreter.new()
 	_interpreter.init(file, {
 		"id_suffix_lookup_separator": _config_id_suffix_lookup_separator(),
+		"include_hidden_options": _options.get("include_hidden_options", false)
 	})
 	_interpreter.connect("variable_changed",Callable(self,"_trigger_variable_changed"))
 	_interpreter.connect("event_triggered",Callable(self,"_trigger_event_triggered"))
@@ -53,7 +62,7 @@ func start(block_name = null):
 
 
 ## Get next dialogue content. [br]
-## The content may be a line, options or null. If null, it means the dialogue reached an end.
+## The content may be a line, options or end of dialogue.
 func get_content():
 	return _interpreter.get_content()
 


### PR DESCRIPTION
Feature request: #10 

Added configuration to return options that didn't pass checks.
```gdscript
dialogue.configure({ "include_hidden_options": true }) # default is false
``` 

For example:
```
* option 1 { is_this_true }
        some dialogue
* option 2
        some other dialogue
``` 

By default, if is_this_true is false, option 1 won't be included in the options list when doing `get_content`. When this new configuration is enabled, all non-used options are returned. They will also contain an extra property ` is_visible` that indicates if they are supposed to be shown or not.