### PR TITLE
Change block identifier for persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-Dialogues now return an object when ended.
+- Dialogues now return an object when ended. This impacts how you determined if the dialogue has ended.
+- Changed identifier for blocks when persisting so changing block order does not impact already saved files. This will impact variations and single use options on all existing save files.
 
 ### Added
 
@@ -21,7 +22,8 @@ Dialogues now return an object when ended.
 ### Fixed
 
 - Use correct `fmod` for `a %=` operations.
-- Fixed crash when exiting editor started via command line (@Rubonnek)
+- Fixed crash when exiting editor started via command line (@Rubonnek).
+- Changing block order in file does not impact persisted options and variations anymore.
 
 ### Thanks
 

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -16,7 +16,7 @@ var _config
 
 func init(document, interpreter_options = {}):
 	_doc = document
-	_doc._index = 1
+	_doc._index = "r"
 	_mem = Memory.new()
 	_mem.connect("variable_changed",Callable(self,"_trigger_variable_changed"))
 	_logic = LogicInterpreter.new()
@@ -101,7 +101,7 @@ func _initialise_stack(root):
 
 func _initialise_blocks(doc):
 	for i in range(doc.blocks.size()):
-		doc.blocks[i]._index = i + 2
+		doc.blocks[i]._index = "b_%s" % doc.blocks[i].name
 		_anchors[doc.blocks[i].name] = doc.blocks[i]
 
 
@@ -122,7 +122,7 @@ func _add_to_stack(node):
 
 
 func _generate_index():
-	return (10 * _stack_head().current._index) + _stack_head().content_index
+	return "%s_%s" % [_stack_head().current._index, _stack_head().content_index]
 
 
 func _initialize_handlers():
@@ -216,7 +216,7 @@ func _get_visible_options(options):
 
 func _prepare_option(option, index, should_include_hidden = false, is_visible = true):
 	if option.get("index") == null:
-		option._index = _generate_index() * 100 + index
+		option._index = "%s_%s" % [_generate_index(), index]
 
 	if option.type == 'conditional_content':
 		option.content._index = option._index;
@@ -290,7 +290,7 @@ func _handle_variations_node(variations, attempt = 0):
 		variations["_index"] = _generate_index()
 		for index in range(variations.content.size()):
 			var c = variations.content[index]
-			c._index = _generate_index() * 100 + index
+			c._index = "%s_%s" % [_generate_index(), index]
 
 	var next = _handle_variation_mode(variations)
 	if next == -1 or attempt > variations.content.size():
@@ -439,9 +439,9 @@ func _handle_sequence_variation(variations):
 
 
 func _handle_shuffle_variation(variations, mode = 'cycle'):
-	var SHUFFLE_VISITED_KEY = "%s_shuffle_visited" % variations._index;
-	var LAST_VISITED_KEY = "%s_last_index" % variations._index;
-	var visited_items = _mem.get_internal_variable(SHUFFLE_VISITED_KEY, []);
+	var SHUFFLE_VISITED_KEY = "%s_shuffle_visited" % variations._index
+	var LAST_VISITED_KEY = "%s_last_index" % variations._index
+	var visited_items = _mem.get_internal_variable(SHUFFLE_VISITED_KEY, [])
 	var remaining_options = []
 	for o in variations.content:
 		if not visited_items.has(o._index):
@@ -452,18 +452,18 @@ func _handle_shuffle_variation(variations, mode = 'cycle'):
 			return -1
 
 		if mode == 'cycle':
-			_mem.set_internal_variable(SHUFFLE_VISITED_KEY, []);
+			_mem.set_internal_variable(SHUFFLE_VISITED_KEY, [])
 			return _handle_shuffle_variation(variations, mode)
-		return _mem.get_internal_variable(LAST_VISITED_KEY, -1);
+		return _mem.get_internal_variable(LAST_VISITED_KEY, -1)
 
 	randomize()
 	var random = randi() % remaining_options.size()
-	var index = variations.content.find(remaining_options[random]);
+	var index = variations.content.find(remaining_options[random])
 
-	visited_items.push_back(remaining_options[random]._index);
+	visited_items.push_back(remaining_options[random]._index)
 
 	_mem.set_internal_variable(LAST_VISITED_KEY, index);
-	_mem.set_internal_variable(SHUFFLE_VISITED_KEY, visited_items);
+	_mem.set_internal_variable(SHUFFLE_VISITED_KEY, visited_items)
 
 	return index;
 

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -532,6 +532,48 @@ func test_persisted_data_control_variations():
 	assert_eq_deep(dialogue2.get_content().text, "Hey")
 
 
+func test_changing_block_order_does_not_affect_persistence():
+	var interpreter = ClydeDialogue.Interpreter.new()
+	var dialogue_block_1 = """
+== block_1
+* option 1
+	line
+* option 2
+	line
+"""
+	var dialogue_block_2 = """
+== block_2
+* option 1
+	line
+* option 2
+	line
+"""
+
+	var content = parse(dialogue_block_1 + dialogue_block_2)
+	interpreter.init(content)
+	interpreter.select_block("block_1")
+
+	interpreter.get_content()
+	interpreter.choose(0)
+
+	var data = interpreter.get_data()
+
+	var inverted_content = parse(dialogue_block_2 + dialogue_block_1)
+	interpreter.init(inverted_content)
+	interpreter.load_data(data)
+
+	interpreter.select_block("block_1")
+
+	var block_1_options = interpreter.get_content()
+
+	interpreter.select_block("block_2")
+	var block_2_options = interpreter.get_content()
+
+
+	assert_eq_deep(block_1_options, _options({ "options": [_option({ "label": "option 2" })] }))
+	assert_eq_deep(block_2_options, _options({ "options": [_option({ "label": "option 1" }), _option({ "label": "option 2" })] }))
+
+
 var pending_events = []
 
 func test_events():


### PR DESCRIPTION
Changed identifier for blocks when persisting so changing block order does not impact already saved files. This will impact variations and single use options on all existing save files.

This is a breaking change.