### PR TITLE
Change variation shuffle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Dialogues now return an object when ended. This impacts how you determined if the dialogue has ended.
 - Changed identifier for blocks when persisting so changing block order does not impact already saved files. This will impact variations and single use options on all existing save files.
+- Variation standalone `shuffle` option does simple random and has no guarantee every item will be returned.
 
 ### Added
 
@@ -18,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Increment assigment now have default values. i.e. If you run `set a += 1` when `a` is not set, it will be set to 1. Before it would break because value was null.
     - As `+` is also used for strings, this `set a += "abc"` also works.
 - Return end object (`{ "type": "end" }`) instead of null on dialogue end.
+- Make variation `shuffle` option be really random. There is no guarantee all items will be executed.
 
 ### Fixed
 

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -398,7 +398,7 @@ func _handle_variation_mode(variations):
 		"once":
 			return _handle_once_variation(variations)
 		"shuffle":
-			return _handle_shuffle_variation(variations)
+			return _handle_real_shuffle_variation(variations)
 		"shuffle sequence":
 			return _handle_shuffle_variation(variations, "sequence")
 		"shuffle once":
@@ -466,6 +466,11 @@ func _handle_shuffle_variation(variations, mode = 'cycle'):
 	_mem.set_internal_variable(SHUFFLE_VISITED_KEY, visited_items)
 
 	return index;
+
+
+func _handle_real_shuffle_variation(variations):
+	randomize()
+	return randi() % variations.content.size()
 
 
 func _trigger_variable_changed(name, value, previous_value):

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -350,26 +350,17 @@ func test_variations():
 			random_cycle = ["multiline example do you think it works?", "yep"]
 
 
-func _test_variation_default_shuffle_is_cycle():
+func test_variation_default_shuffle():
 	var interpreter = ClydeDialogue.Interpreter.new()
-	var content = parse("( shuffle \n- { a } A\n -  { b } B\n)\nend\n")
+	var content = parse("( shuffle \n - A\n - B\n)\nend\n")
 	interpreter.init(content)
 
-	var random_default_cycle = ["a", "b"]
-	for _i in range(2):
+	var random_default_cycle = ["A", "B"]
+	for _i in range(5):
+		interpreter.select_block()
 		var rdc = interpreter.get_content().text
+		print(rdc)
 		assert_has(random_default_cycle, rdc)
-		random_default_cycle.erase(rdc)
-
-	assert_eq(random_default_cycle.size(), 0)
-	# should re-shuffle after exausting all options
-	random_default_cycle = ["a", "b"]
-	for _i in range(2):
-		var rdc = interpreter.get_content().text
-		assert_has(random_default_cycle, rdc)
-		random_default_cycle.erase(rdc)
-
-	assert_eq(random_default_cycle.size(), 0)
 
 
 func test_all_variations_not_available():


### PR DESCRIPTION
Variation shuffle used to work like shuffle cycle. It was guaranteed all items would be returned at least once.
Change the behaviour to be really random. `shuffle cycle` still has same behaviour.