### PR TITLE
Add a `has_block` method to check if a dialogue contains a given block

### DIFF
--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -61,6 +61,11 @@ func start(block_name = null):
 	_interpreter.select_block(block_name)
 
 
+## Checks if a block with the given name exists.
+func has_block(block_name):
+	return _interpreter.has_block(block_name)
+
+
 ## Get next dialogue content. [br]
 ## The content may be a line, options or end of dialogue.
 func get_content():

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -72,6 +72,10 @@ func select_block(block_name = null):
 		_initialise_stack(_doc)
 
 
+func has_block(block_name):
+	return block_name in _anchors
+
+
 func get_variable(name):
 	return _mem.get_variable(name)
 


### PR DESCRIPTION
I ran into this issue when I was trying to add multiple dialogues in the same file and separate them using blocks, but the `start` function gives an error if called with a block name that does not exist, so I though it could use a `has_block` method to check if a given block exists.

For example, one could use it to default to a "default block" when a block with the given name does not exist.
```
if dialogue.has_block(block_name):
    dialogue.start(block_name)
else:
    dialogue.start("default_block")
```

There might be some other use cases for it, and since it only requires two accessor methods I though it would be a useful addition.