### PR TITLE
Allow defining speaker to multiple lines at once by indenting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Allow defining speaker to multiple lines at once by indenting them.
+i.e
+```
+Vinny:
+    Multiple lines can be set with same speaker.
+    You just need to indent them after the speaker line.
+    Grouping lines also work this way
+        by indenting the line further.
+```
+
 ## 5.0.0 (2024-09-11)
 
 ### Breaking changes

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -128,12 +128,16 @@ func _lines():
 
 	if tk.token == Lexer.TOKEN_SPEAKER or tk.token == Lexer.TOKEN_TEXT:
 		_tokens.consume([ Lexer.TOKEN_SPEAKER, Lexer.TOKEN_TEXT ])
-		var line = _line()
-		if _tokens.has_next([Lexer.TOKEN_BRACE_OPEN]):
-			_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
-			lines = [_line_with_action(line)]
+
+		if tk.token == Lexer.TOKEN_SPEAKER and _tokens.has_next([Lexer.TOKEN_INDENT]):
+			lines = _lines_with_speaker()
 		else:
-			lines = [line]
+			var line = _line()
+			if _tokens.has_next([Lexer.TOKEN_BRACE_OPEN]):
+				_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
+				lines = [_line_with_action(line)]
+			else:
+				lines = [line]
 	elif tk.token == Lexer.TOKEN_OPTION or tk.token == Lexer.TOKEN_STICKY_OPTION or tk.token == Lexer.TOKEN_FALLBACK_OPTION:
 		lines = [_options()]
 	elif tk.token == Lexer.TOKEN_DIVERT or tk.token == Lexer.TOKEN_DIVERT_PARENT:
@@ -170,6 +174,28 @@ func _dialogue_line():
 			return _line_with_speaker()
 		Lexer.TOKEN_TEXT:
 			return _text_line()
+
+
+func _lines_with_speaker():
+	var speaker_token = _tokens.current_token
+	var lines = []
+	_tokens.consume([Lexer.TOKEN_INDENT])
+
+	while not _tokens.has_next([Lexer.TOKEN_DEDENT, Lexer.TOKEN_EOF]):
+		_tokens.consume([Lexer.TOKEN_TEXT])
+		var line = _text_line()
+		line.speaker = speaker_token.value;
+
+		if _tokens.has_next([Lexer.TOKEN_BRACE_OPEN]):
+			_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
+			lines.push_back(_line_with_action(line))
+		else:
+			lines.push_back(line)
+
+	if _tokens.has_next([Lexer.TOKEN_DEDENT]):
+		_tokens.consume([Lexer.TOKEN_DEDENT])
+
+	return lines
 
 
 func _line_with_speaker():

--- a/addons/gut/fonts/AnonymousPro-Bold.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Bold.ttf-9d8fef4d357af5b52cd60af
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-BoldItalic.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-BoldItalic.ttf-4274bf704d3d6b9cd
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-Italic.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Italic.ttf-9989590b02137b799e13d
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/AnonymousPro-Regular.ttf.import
+++ b/addons/gut/fonts/AnonymousPro-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/AnonymousPro-Regular.ttf-856c843fd6f89964d2ca
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Bold.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Bold.ttf-1f003c66d63ebed70964e77
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-BoldItalic.ttf.import
+++ b/addons/gut/fonts/CourierPrime-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-BoldItalic.ttf-65ebcc61dd5e1dfa8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Italic.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Italic.ttf-baa9156a73770735a0f72
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/CourierPrime-Regular.ttf.import
+++ b/addons/gut/fonts/CourierPrime-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/CourierPrime-Regular.ttf-3babe7e4a7a588dfc9a8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Bold.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Bold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Bold.ttf-7c7f734103b58a32491a47881
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-BoldItalic.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-BoldItalic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-BoldItalic.ttf-227406a33e84448e6aa
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Italic.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Italic.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Italic.ttf-f93abf6c25390c85ad5fb6c
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/addons/gut/fonts/LobsterTwo-Regular.ttf.import
+++ b/addons/gut/fonts/LobsterTwo-Regular.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/LobsterTwo-Regular.ttf-f3fcfa01cd671c8da433dd
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="clyde-plugin"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [autoload]

--- a/test/test_parser_lines.gd
+++ b/test/test_parser_lines.gd
@@ -119,3 +119,40 @@ this is a nested option
 	assert_eq_deep(result.content[0].content[1].meta, { "line": 3, "column": 0 })
 	assert_eq_deep(result.content[0].content[2].meta, { "line": 4, "column": 0 })
 	assert_eq_deep(result.blocks[0].meta, { "line": 7, "column": 0 })
+
+
+func test_parse_lines_grouped_by_speaker():
+		var result = parse("""
+jules:
+	First line $first #yelling #mad
+	Second line $second #sec
+	Third line w multi line $third #t
+		Still third line
+	This is conditional { some_var }
+	Fourth line $fourth
+vincent:
+	Another one
+
+""")
+
+		var expected = {
+			"type": 'document',
+			"content": [{
+				"type": 'content',
+				"content": [
+					{ "type": 'line', "value": 'First line', "id": 'first', "speaker": 'jules', "tags": [ 'yelling', 'mad' ], "id_suffixes": null },
+					{ "type": 'line', "value": 'Second line', "id": 'second', "speaker": 'jules', "tags": [ 'sec' ], "id_suffixes": null },
+					{ "type": 'line', "value": 'Third line w multi line Still third line', "id": 'third', "speaker": 'jules', "tags": [ 't' ], "id_suffixes": null },
+					{
+						"type": "conditional_content",
+						"conditions": { "type": "variable", "name": "some_var" },
+						"content": { "type": 'line', "value": 'This is conditional', "id": null, "speaker": 'jules', "tags": [], "id_suffixes": null },
+					},
+					{"type": 'line', "value": 'Fourth line', "id": "fourth", "speaker": 'jules', "tags": [], "id_suffixes": null },
+					{"type": 'line', "value": 'Another one', "id": null, "speaker": 'vincent', "tags": [], "id_suffixes": null }
+				]
+			}],
+			"blocks": []
+		}
+
+		assert_eq_deep(result, expected)


### PR DESCRIPTION
Allow defining speaker to multiple lines at once by indenting them.
i.e
```
Vinny:
    Multiple lines can be set with same speaker.
    You just need to indent them after the speaker line.
    Grouping lines also work this way
        by indenting the line further.
```