### PR TITLE
Allow defining speaker to multiple lines at once by indenting them (Godot 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Allow defining speaker to multiple lines at once by indenting them.
+i.e
+```
+Vinny:
+    Multiple lines can be set with same speaker.
+    You just need to indent them after the speaker line.
+    Grouping lines also work this way
+        by indenting the line further.
+```
+
 ## 5.0.0 (2024-09-11)
 
 ### Breaking changes

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -121,12 +121,16 @@ func _lines():
 
 	if tk.token == Lexer.TOKEN_SPEAKER or tk.token == Lexer.TOKEN_TEXT:
 		_tokens.consume([ Lexer.TOKEN_SPEAKER, Lexer.TOKEN_TEXT ])
-		var line = _line()
-		if _tokens.peek([Lexer.TOKEN_BRACE_OPEN]):
-			_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
-			lines = [_line_with_action(line)]
+	
+		if tk.token == Lexer.TOKEN_SPEAKER and _tokens.has_next([Lexer.TOKEN_INDENT]):
+			lines = _lines_with_speaker()
 		else:
-			lines = [line]
+			var line = _line()
+			if _tokens.has_next([Lexer.TOKEN_BRACE_OPEN]):
+				_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
+				lines = [_line_with_action(line)]
+			else:
+				lines = [line]
 	elif tk.token == Lexer.TOKEN_OPTION or tk.token == Lexer.TOKEN_STICKY_OPTION or tk.token == Lexer.TOKEN_FALLBACK_OPTION:
 		lines = [_options()]
 	elif tk.token == Lexer.TOKEN_DIVERT or tk.token == Lexer.TOKEN_DIVERT_PARENT:
@@ -164,6 +168,29 @@ func _dialogue_line():
 			return _line_with_speaker()
 		Lexer.TOKEN_TEXT:
 			return _text_line()
+
+
+func _lines_with_speaker():
+	var speaker_token = _tokens.current_token
+	var lines = []
+	_tokens.consume([Lexer.TOKEN_INDENT])
+
+	while not _tokens.has_next([Lexer.TOKEN_DEDENT, Lexer.TOKEN_EOF]):
+		_tokens.consume([Lexer.TOKEN_TEXT])
+		var line = _text_line()
+		line.speaker = speaker_token.value;
+
+		if _tokens.has_next([Lexer.TOKEN_BRACE_OPEN]):
+			_tokens.consume([Lexer.TOKEN_BRACE_OPEN])
+			lines.push_back(_line_with_action(line))
+		else:
+			lines.push_back(line)
+
+	if _tokens.has_next([Lexer.TOKEN_DEDENT]):
+		_tokens.consume([Lexer.TOKEN_DEDENT])
+
+	return lines
+
 
 func _line_with_speaker():
 	var value = _tokens.current_token.value

--- a/addons/clyde/parser/TokenWalker.gd
+++ b/addons/clyde/parser/TokenWalker.gd
@@ -38,6 +38,10 @@ func peek(expected = null, offset = 0):
 		return lookahead
 
 
+func has_next(expected = null, offset = 0) -> bool:
+	return peek(expected, offset) != null
+
+
 func _wrong_token_error(token, expected):
 	var expected_hints = []
 	for e in expected:

--- a/test/test_parser_lines.gd
+++ b/test/test_parser_lines.gd
@@ -101,3 +101,40 @@ Just talking.\"
 		"blocks": []
 	}
 	assert_eq_deep(result, expected)
+
+
+func test_parse_lines_grouped_by_speaker():
+		var result = parse("""
+jules:
+	First line $first #yelling #mad
+	Second line $second #sec
+	Third line w multi line $third #t
+		Still third line
+	This is conditional { some_var }
+	Fourth line $fourth
+vincent:
+	Another one
+
+""")
+
+		var expected = {
+			"type": 'document',
+			"content": [{
+				"type": 'content',
+				"content": [
+					{ "type": 'line', "value": 'First line', "id": 'first', "speaker": 'jules', "tags": [ 'yelling', 'mad' ], "id_suffixes": null },
+					{ "type": 'line', "value": 'Second line', "id": 'second', "speaker": 'jules', "tags": [ 'sec' ], "id_suffixes": null },
+					{ "type": 'line', "value": 'Third line w multi line Still third line', "id": 'third', "speaker": 'jules', "tags": [ 't' ], "id_suffixes": null },
+					{
+						"type": "conditional_content",
+						"conditions": { "type": "variable", "name": "some_var" },
+						"content": { "type": 'line', "value": 'This is conditional', "id": null, "speaker": 'jules', "tags": null, "id_suffixes": null },
+					},
+					{"type": 'line', "value": 'Fourth line', "id": "fourth", "speaker": 'jules', "tags": null, "id_suffixes": null },
+					{"type": 'line', "value": 'Another one', "id": null, "speaker": 'vincent', "tags": null, "id_suffixes": null }
+				]
+			}],
+			"blocks": []
+		}
+
+		assert_eq_deep(result, expected)


### PR DESCRIPTION
Allow defining speaker to multiple lines at once by indenting them.
i.e
```
Vinny:
    Multiple lines can be set with same speaker.
    You just need to indent them after the speaker line.
    Grouping lines also work this way
        by indenting the line further.
```

port from #51