### PR TITLE
Allow more chars in tags and ids (Godot 3)

### DIFF
--- a/.gut_editor_config.json
+++ b/.gut_editor_config.json
@@ -20,7 +20,7 @@
  "post_run_script": "",
  "pre_run_script": "",
  "prefix": "test_",
- "selected": null,
+ "selected": "test_lexer.gd",
  "should_exit": true,
  "should_exit_on_success": true,
  "should_maximize": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Vinny:
         by indenting the line further.
 ```
 
+### Changed
+
+- Tags now also accept `.` and `-`.
+- Variables now can start with `_`.
+
 ## 5.0.0 (2024-09-11)
 
 ### Breaking changes

--- a/addons/clyde/parser/Lexer.gd
+++ b/addons/clyde/parser/Lexer.gd
@@ -366,7 +366,7 @@ func _handle_tag():
 	_position += 1
 	_column += 1
 
-	while _is_valid_position() and _is_identifier(_input[_position]):
+	while _is_valid_position() and _is_tag(_input[_position]):
 		values.push_back(_input[_position])
 		_position += 1
 		_column += 1
@@ -777,8 +777,16 @@ func _is_tab_char(character):
 	tab.compile("[\t ]")
 	return tab.search(character) != null
 
+
 func _is_valid_position():
 	return _position < _input.length() and _input[_position]
+
+
+func _is_tag(character):
+	var lineId = RegEx.new()
+	lineId.compile("[A-Z|a-z|0-9|_|\\.|\\-]")
+	return lineId.search(character) != null
+
 
 func _is_identifier(character):
 	var lineId = RegEx.new()

--- a/addons/clyde/parser/Lexer.gd
+++ b/addons/clyde/parser/Lexer.gd
@@ -635,7 +635,7 @@ func _handle_logic_block():
 		return _handle_logic_number()
 
 	var identifier_start = RegEx.new()
-	identifier_start.compile("[A-Z|a-z|@]")
+	identifier_start.compile("[A-Z|a-z|@|_]")
 	if identifier_start.search(_input[_position]) != null:
 		return _handle_logic_identifier()
 

--- a/test/test_lexer.gd
+++ b/test/test_lexer.gd
@@ -404,13 +404,13 @@ speaker1: this is something $123&var1
 func test_tags():
 	var lexer = Lexer.new()
 	var tokens = lexer.init("""
-this is something #hello #happy #something_else
+this is something #hell_o #happy.mm #something-else
 """).get_all()
 	assert_eq_deep(tokens, [
 		{ "token": Lexer.TOKEN_TEXT, "value": 'this is something', "line": 1, "column": 0 },
-		{ "token": Lexer.TOKEN_TAG, "value": 'hello', "line": 1, "column": 18 },
-		{ "token": Lexer.TOKEN_TAG, "value": 'happy', "line": 1, "column": 25 },
-		{ "token": Lexer.TOKEN_TAG, "value": 'something_else', "line": 1, "column": 32 },
+		{ "token": Lexer.TOKEN_TAG, "value": 'hell_o', "line": 1, "column": 18 },
+		{ "token": Lexer.TOKEN_TAG, "value": 'happy.mm', "line": 1, "column": 26 },
+		{ "token": Lexer.TOKEN_TAG, "value": 'something-else', "line": 1, "column": 36 },
 		{ "token": Lexer.TOKEN_EOF, "line": 2, "column": 0, "value": null },
 	])
 

--- a/test/test_lexer.gd
+++ b/test/test_lexer.gd
@@ -576,7 +576,7 @@ func test_variables_conditions():
 { variable == true }
 { variable == false }
 { variable == \"s1\" }
-{ variable == null }
+{ _variable == null }
 { @global_variable }
 
 """).get_all()
@@ -741,11 +741,11 @@ func test_variables_conditions():
 
 		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 23, "column": 0, "value": null, },
 		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 23, "column": 0, "value": null, },
-		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'variable', "line": 23, "column": 2, },
-		{ "token": Lexer.TOKEN_EQUAL, "line": 23, "column": 11, "value": null, },
-		{ "token": Lexer.TOKEN_NULL_TOKEN, "line": 23, "column": 14, "value": null, },
-		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 23, "column": 19, "value": null, },
-		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 23, "column": 20, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": '_variable', "line": 23, "column": 2, },
+		{ "token": Lexer.TOKEN_EQUAL, "line": 23, "column": 12, "value": null, },
+		{ "token": Lexer.TOKEN_NULL_TOKEN, "line": 23, "column": 15, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 23, "column": 20, "value": null, },
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 23, "column": 21, "value": null, },
 
 		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 24, "column": 0, "value": null },
 		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 24, "column": 0, "value": null, },


### PR DESCRIPTION
- Tags now also accept `.` and `-`.
- Variables now can start with `_`.

Related to #53 