### PR TITLE
Events with parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Breaking changes
+
+`event_triggered` signal expects two parameters now `event_triggered(event_name: String, parameters: [])`
+
+### Changed
+
+- Support events with parameters (e.g `{ trigger event(param1, param2, "text", ...) }`)
+
 ## 5.1.0 (2024-10-07)
 
 ### Added

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,7 @@ This is `ClydeDialogue`'s interface:
 extends Node
 
 signal variable_changed(variable_name: String, value; Variant, previous_vale: Variant)
-signal event_triggered(event_name; String)
+signal event_triggered(event_name: String, parameters: Array)
 
 # Load dialogue file
 # file_name: path to the dialogue file.
@@ -196,7 +196,7 @@ You can listen to events triggered by the dialogue by observing the `event_trigg
   dialogue.connect('event_triggered', self, '_on_event_triggered')
 
 
-func _on_event_triggered(event_name):
+func _on_event_triggered(event_name, parameters):
   if event_name == 'self_destruction_activated':
     _shake_screen()
     _play_explosion()

--- a/USAGE.md
+++ b/USAGE.md
@@ -177,13 +177,10 @@ You can listen to variable changes by observing the `variable_changed` signal.
 ``` gdscript
   # ...
 
-  dialogue.connect('variable_changed', self, '_on_variable_changed')
-
-
-func _on_variable_changed(variable_name, value, previous_vale):
-  if variable_name == 'hp' and value < previous_value:
-    print('damage taken')
-
+  dialogue.variable_changed.connect(func (variable_name, value, previous_vale):
+    if variable_name == 'hp' and value < previous_value:
+      print('damage taken')
+  )
 ```
 
 ### Listening to events
@@ -193,14 +190,11 @@ You can listen to events triggered by the dialogue by observing the `event_trigg
 ``` gdscript
   # ...
 
-  dialogue.connect('event_triggered', self, '_on_event_triggered')
-
-
-func _on_event_triggered(event_name, parameters):
-  if event_name == 'self_destruction_activated':
-    _shake_screen()
-    _play_explosion()
-
+  dialogue.event_triggered.connect(func (event_name, parameters):
+    if event_name == 'self_destruction_activated':
+      _shake_screen()
+      _play_explosion()
+  )
 ```
 
 ### Data persistence

--- a/addons/clyde/ClydeDialogue.gd
+++ b/addons/clyde/ClydeDialogue.gd
@@ -13,7 +13,7 @@ const FileLoader = preload("./file_loader.gd")
 ## Emits when a variable is changed inside the dialogue.
 signal variable_changed(name: String, value: Variant, previous_value: Variant)
 ## Emits when an event is triggered inside the dialogue.
-signal event_triggered(name: String)
+signal event_triggered(name: String, parameters: Array)
 
 ## Type for regular dialogue line
 const CONTENT_TYPE_LINE = Interpreter.CONTENT_TYPE_LINE
@@ -165,8 +165,8 @@ func _trigger_variable_changed(name: String, value: Variant, previous_value: Var
 	variable_changed.emit(name, value, previous_value)
 
 
-func _trigger_event_triggered(name: String) -> void:
-	event_triggered.emit(name)
+func _trigger_event_triggered(name: String, parameters: Array) -> void:
+	event_triggered.emit(name, parameters)
 
 
 func _config_id_suffix_lookup_separator() -> String:

--- a/addons/clyde/editor/editor/clyde_syntax_highlighter.gd
+++ b/addons/clyde/editor/editor/clyde_syntax_highlighter.gd
@@ -306,6 +306,11 @@ func _handle_logic_mode(content: String, current_column: int, no_previous_text: 
 	while current_column < content.length():
 		var character = content[current_column]
 
+		if character == "(" or character == ")":
+			regions[current_column] = _symbol_region()
+			current_column += 1
+			continue
+
 		if character == "\"" or character == "'":
 			current_column = _handle_logic_string_literal(current_column, content, regions)
 			continue
@@ -356,7 +361,7 @@ func _handle_link(content: String, current_column: int, regions: Dictionary) -> 
 		current_column += 1
 
 	regions[current_column] = _identifier_region()
-	
+
 	while current_column < content.length() and _identifier_regex.search(content[current_column]) != null:
 		current_column += 1
 
@@ -373,7 +378,7 @@ func _handle_link(content: String, current_column: int, regions: Dictionary) -> 
 
 	while current_column < content.length() and content[current_column] == " ":
 		current_column += 1
-		
+
 	if current_column < content.length():
 		regions[current_column] = _string_literal_region()
 		while current_column < content.length():

--- a/addons/clyde/editor/main_panel.gd
+++ b/addons/clyde/editor/main_panel.gd
@@ -410,9 +410,9 @@ func _on_player_external_variable_changed(var_name, value, old_value):
 		_debug_panel.set_external_variable(var_name, value, old_value)
 
 
-func _on_player_event_triggered(event_name):
+func _on_player_event_triggered(event_name, parameters):
 	if _debug_panel != null:
-		_debug_panel.record_event(event_name)
+		_debug_panel.record_event(event_name, parameters)
 
 
 func _on_player_dialogue_mem_clean():

--- a/addons/clyde/editor/player/debug_dock.gd
+++ b/addons/clyde/editor/player/debug_dock.gd
@@ -68,8 +68,8 @@ func load_external_variables(external_variables: Dictionary):
 	_external_variables.load_data(external_variables)
 
 
-func record_event(event_name: String):
-	_debug_history.record_event(event_name)
+func record_event(event_name: String, parameters: Array):
+	_debug_history.record_event(event_name, parameters)
 
 
 func _on_scrollbar_changed():

--- a/addons/clyde/editor/player/debug_dock_history_entries.gd
+++ b/addons/clyde/editor/player/debug_dock_history_entries.gd
@@ -10,8 +10,8 @@ func _init(event_entries: GridContainer) -> void:
 	_event_entries = event_entries
 
 
-func record_event(event_name: String):
-	_add_event_record(event_name)
+func record_event(event_name: String, parameters: Array):
+	_add_event_record(event_name, parameters)
 
 
 func clear_event_history():
@@ -44,15 +44,17 @@ func _create_event_history_header():
 	_add_separator()
 
 
-func _add_event_record(event_name: String):
+func _add_event_record(event_name: String, parameters: Array):
 	var type = Label.new()
 	type.text = InterfaceText.get_string(InterfaceText.KEY_DEBUG_EVENT_LABEL)
 	var name = Label.new()
 	name.text = event_name
+	var val = Label.new()
+	val.text = str(parameters)
 	_event_entries.add_child(_time_field())
 	_event_entries.add_child(type)
 	_event_entries.add_child(name)
-	_event_entries.add_child(Label.new()) # value stub
+	_event_entries.add_child(val)
 	_event_entries.add_child(Label.new()) # old value stub
 	_add_separator()
 

--- a/addons/clyde/editor/player/player.gd
+++ b/addons/clyde/editor/player/player.gd
@@ -8,7 +8,7 @@ signal toggle_debug_panel(is_visible: bool)
 signal dialogue_mem_clean
 signal variable_changed(var_name, value, old_value)
 signal external_variable_changed(var_name, value, old_value)
-signal event_triggered(event_name)
+signal event_triggered(event_name, parameters)
 signal close_triggered
 
 const InterfaceText = preload("../config/interface_text.gd")
@@ -345,8 +345,8 @@ func _on_variable_changed(var_name: String, value, old_value):
 	variable_changed.emit(var_name, value, old_value)
 
 
-func _on_event_triggered(event_name: String):
-	event_triggered.emit(event_name)
+func _on_event_triggered(event_name: String, parameters: Array):
+	event_triggered.emit(event_name, parameters)
 
 
 func _add_initial_line():

--- a/addons/clyde/examples/examples_with_helpers/fixed_bubble/example_fixed_with_helpers.gd
+++ b/addons/clyde/examples/examples_with_helpers/fixed_bubble/example_fixed_with_helpers.gd
@@ -55,8 +55,8 @@ func _on_variable_changed(variable_name: String, value: Variant, old_value: Vari
 
 # Listen to events triggered by dialogue.
 # One usage example is to do stuff like screen shake, play sounds or specific animations.
-func _on_event_triggered(event_name: String):
-	print("Event triggered: '%s'" % event_name)
+func _on_event_triggered(event_name: String, parameters: Array):
+	print("Event triggered: '%s' params: %s" % [ event_name, parameters ])
 
 
 # This event is useful for when you want to animate your speaker without hooking it

--- a/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.gd
+++ b/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.gd
@@ -60,8 +60,8 @@ func _on_variable_changed(variable_name: String, value: Variant, old_value: Vari
 
 # Listen to events triggered by dialogue.
 # One usage example is to do stuff like screen shake, play sounds or specific animations.
-func _on_event_triggered(event_name: String):
-	print("Event triggered: '%s'" % event_name)
+func _on_event_triggered(event_name: String, parameters: Array):
+	print("Event triggered: '%s' params: %s" % [ event_name, parameters ])
 
 
 # This event is useful for when you want to animate your speaker without hooking it

--- a/addons/clyde/examples/simple_example/example.gd
+++ b/addons/clyde/examples/simple_example/example.gd
@@ -15,8 +15,8 @@ func _ready():
 	_dialogue = ClydeDialogue.new()
 	_dialogue.load_dialogue('pulp_with_blocks')
 
-	_dialogue.connect("event_triggered",Callable(self,'_on_event_triggered'))
-	_dialogue.connect("variable_changed",Callable(self,'_on_variable_changed'))
+	_dialogue.event_triggered.connect(_on_event_triggered)
+	_dialogue.variable_changed.connect(_on_variable_changed)
 
 	_dialogue.on_external_variable_fetch(_on_external_variable_fetch)
 	_dialogue.on_external_variable_update(_on_external_variable_update)
@@ -72,8 +72,8 @@ func _gui_input(event):
 		_get_next_dialogue_line()
 
 
-func _on_event_triggered(event_name):
-	print("Event received: %s" % event_name)
+func _on_event_triggered(event_name, parameters):
+	print("Event received: %s params: %s " % [event_name, parameters])
 
 
 func _on_variable_changed(variable_name, new_value, previous_value):

--- a/addons/clyde/helpers/dialogue_manager.gd
+++ b/addons/clyde/helpers/dialogue_manager.gd
@@ -7,7 +7,7 @@ const DialogueBubbleFixed = preload("res://addons/clyde/helpers/bubbles/dialogue
 signal dialogue_started(dialogue_path: String, block: String)
 signal dialogue_ended(dialogue_path: String, block: String)
 signal variable_changed(variable_name: String, value: Variant, old_value: Variant)
-signal event_triggered(event_name: String)
+signal event_triggered(event_name: String, parameters: Array)
 signal speaker_changed(current_speaker: String, previous_speaker: String)
 
 var config
@@ -159,8 +159,8 @@ func _on_variable_changed(variable_name: String, value: Variant, old_value: Vari
 	variable_changed.emit(variable_name, value, old_value)
 
 
-func _on_event_triggered(event_name: String):
-	event_triggered.emit(event_name)
+func _on_event_triggered(event_name: String, parameters: Array):
+	event_triggered.emit(event_name, parameters)
 
 
 func _next_content() -> void:

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -1,7 +1,7 @@
 extends RefCounted
 
 signal variable_changed(name: String, value: Variant, previous_value: Variant)
-signal event_triggered(event_name: String)
+signal event_triggered(event_name: String, parameters: Array)
 
 const Memory = preload("./Memory.gd")
 const LogicInterpreter = preload("./LogicInterpreter.gd")
@@ -310,11 +310,20 @@ func _handle_action_content_node(action_node):
 
 func _handle_action(action_node):
 	if action_node.action.type == 'events':
-		for event in action_node.action.events:
-			emit_signal("event_triggered", event.name)
+		_trigger_events(action_node.action)
 	else:
 		for assignment in action_node.action.assignments:
 			_logic.handle_assignment(assignment)
+
+
+func _trigger_events(events):
+	for event in events.events:
+		var parameters = []
+
+		if event.get("params", null) != null:
+			parameters = event.params.map(_logic.get_node_value)
+
+		event_triggered.emit(event.name, parameters)
 
 
 func _handle_conditional_content_node(conditional_node, fallback_node = _stack_head().current):
@@ -385,7 +394,7 @@ func _divert_to_linked_doc(link: Dictionary):
 	var doc_path = _doc_anchors[link.link]
 
 	var doc_node
-	
+
 	var actual_path = doc_path
 
 	if doc_path.begins_with("./") or doc_path.begins_with("../"):
@@ -435,9 +444,7 @@ func _handle_assignments_node(assignment_node):
 
 
 func _handle_events_node(events):
-	for event in events.events:
-		emit_signal("event_triggered", event.name)
-
+	_trigger_events(events)
 	return _handle_next_node(_stack_head().current);
 
 

--- a/addons/clyde/interpreter/LogicInterpreter.gd
+++ b/addons/clyde/interpreter/LogicInterpreter.gd
@@ -11,7 +11,7 @@ func init(mem):
 func handle_assignment(assignment):
 	var variable = assignment.variable;
 	var source = assignment.value;
-	var value = _get_node_value(source);
+	var value = get_node_value(source);
 
 	return _handle_assignment_operation(assignment, variable.name, value)
 
@@ -41,7 +41,7 @@ func _handle_assignment_operation(assignment, var_name, value):
 			printerr("Unknown operation %s" % assignment.operation)
 
 
-func _get_node_value(node):
+func get_node_value(node):
 	match node.type:
 		"literal":
 			return node.value
@@ -69,30 +69,30 @@ func check_condition(condition):
 func check_expression(node):
 	match node.name:
 		"equal":
-			return _get_node_value(node.elements[0]) == _get_node_value(node.elements[1])
+			return get_node_value(node.elements[0]) == get_node_value(node.elements[1])
 		"not_equal":
-			return _get_node_value(node.elements[0]) != _get_node_value(node.elements[1])
+			return get_node_value(node.elements[0]) != get_node_value(node.elements[1])
 		"greater_than":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return false
 			return a > b
 		"greater_or_equal":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return false
 			return a >= b
 		"less_than":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return false
 			return a < b
 		"less_or_equal":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return false
 			return a <= b
@@ -103,38 +103,38 @@ func check_expression(node):
 		"not":
 			return not check_condition(node.elements[0])
 		"mult":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return a * b
 		"div":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return a / b
 		"sub":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return a - b
 		"add":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return a + b
 		"pow":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return pow(a, b)
 		"mod":
-			var a = _get_node_value(node.elements[0])
-			var b = _get_node_value(node.elements[1])
+			var a = get_node_value(node.elements[0])
+			var b = get_node_value(node.elements[1])
 			if (a == null || b == null):
 				return null
 			return a % b

--- a/addons/clyde/parser/Lexer.gd
+++ b/addons/clyde/parser/Lexer.gd
@@ -189,6 +189,8 @@ func _get_next_token():
 		if response:
 			return response
 
+
+
 	if _input[_position] == '"' or _input[_position] == "'":
 		if _current_quote:
 			if _input[_position] == _current_quote:
@@ -498,7 +500,7 @@ func _handle_divert():
 	var values = []
 	_position += 2
 	_column += 2
-	
+
 	while _is_valid_position() and _input[_position] == " ":
 		_position += 1
 		_column += 1
@@ -543,7 +545,7 @@ func _handle_divert_ext(initial_column):
 			_column += 1
 
 	return Token(TOKEN_DIVERT, _line, initial_column, { "link": link_name, "block": link_block })
- 
+
 
 
 func _handle_divert_parent():
@@ -635,6 +637,12 @@ func _handle_logic_block():
 
 	if _input[_position] == '}':
 		return _handle_logic_block_stop()
+
+	if _input[_position] == '(':
+		return _create_simple_token(TOKEN_BRACKET_OPEN)
+
+	if _input[_position] == ')':
+		return _create_simple_token(TOKEN_BRACKET_CLOSE)
 
 	if _check_sequence(_input, _position, '=='):
 		return _handle_logic_operator(TOKEN_EQUAL, 2)

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -586,16 +586,32 @@ func _assignments():
 func _events():
 	_tokens.consume([Lexer.TOKEN_KEYWORD_TRIGGER])
 	_tokens.consume([Lexer.TOKEN_IDENTIFIER])
-	var events = [EventNode(_tokens.current_token.value)]
+	var events = [_event(_tokens.current_token.value)]
 
 	while _tokens.has_next([Lexer.TOKEN_COMMA]):
 		_tokens.consume([Lexer.TOKEN_COMMA])
 		_tokens.consume([Lexer.TOKEN_IDENTIFIER])
-		events.push_back(EventNode(_tokens.current_token.value))
+		events.push_back(_event(_tokens.current_token.value))
 
 	_tokens.consume([Lexer.TOKEN_BRACE_CLOSE])
 
 	return EventsNode(events)
+
+
+func _event(event_name: String):
+	if not _tokens.has_next([Lexer.TOKEN_BRACKET_OPEN]):
+		return EventNode(event_name)
+
+	_tokens.consume([Lexer.TOKEN_BRACKET_OPEN])
+
+	var params = [_expression()]
+	while _tokens.has_next([Lexer.TOKEN_COMMA]):
+		_tokens.consume([Lexer.TOKEN_COMMA])
+		params.push_back(_expression())
+
+	_tokens.consume([Lexer.TOKEN_BRACKET_CLOSE])
+
+	return EventNode(event_name, params)
 
 
 func _conditional_line():
@@ -823,8 +839,10 @@ func EventsNode(events):
 	return { "type": 'events', "events": events }
 
 
-func EventNode(name):
-	return { "type": 'event', "name": name }
+func EventNode(name, parameters = null):
+	if parameters == null or parameters.size() == 0:
+		return { "type": 'event', "name": name }
+	return { "type": 'event', "name": name, "params": parameters }
 
 
 func _on_unexpected_token(result: Dictionary):

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -626,13 +626,24 @@ func test_changing_block_order_does_not_affect_persistence():
 	assert_eq_deep(block_2_options, _options({ "options": [_option({ "label": "option 1" }), _option({ "label": "option 2" })] }))
 
 
-var pending_events = []
-
 func test_events():
+	var pending_events = []
+
 	var dialogue = ClydeDialogue.new()
 	dialogue.load_dialogue('variables')
 	dialogue.connect("event_triggered",Callable(self,"_on_event_triggered"))
-	dialogue.connect("variable_changed",Callable(self,"_on_variable_changed"))
+
+	dialogue.event_triggered.connect(func _on_event_triggered(event_name, _params):
+		for e in pending_events:
+			if e.type == 'event' and e.name == event_name:
+				pending_events.erase(e)
+	)
+
+	dialogue.variable_changed.connect(func _on_variable_changed(var_name, value, _previous_value):
+		for e in pending_events:
+			if e.type == 'variable' and e.name == var_name and  typeof(e.value) == typeof(value) and  e.value == value:
+				pending_events.erase(e)
+	)
 
 	pending_events.push_back({ "type": "variable", "name": "xx", "value": true })
 	pending_events.push_back({ "type": "variable", "name": "first_time", "value": 2.0 })
@@ -662,17 +673,27 @@ func test_events():
 	assert_eq(pending_events.size(), 0)
 
 
+func test_events_with_parameters():
+	var interpreter = ClydeDialogue.Interpreter.new()
+	var content = parse("""
+Hi! {set a = 1 }{ trigger some_event(a, "test", true, a + 1) }
+""")
+	interpreter.init(content)
 
-func _on_variable_changed(var_name, value, _previous_value):
-	for e in pending_events:
-		if e.type == 'variable' and e.name == var_name and  typeof(e.value) == typeof(value) and  e.value == value:
-			pending_events.erase(e)
+	var result = { "parameters": null }
 
+	interpreter.event_triggered.connect(func (event_name, params):
+		print("event triggered and all %s %s" % [event_name, params])
+		result.parameters = params
+	)
 
-func _on_event_triggered(event_name):
-	for e in pending_events:
-		if e.type == 'event' and e.name == event_name:
-			pending_events.erase(e)
+	assert_eq_deep(interpreter.get_content().text, 'Hi!')
+
+	while true:
+		if result.parameters != null:
+			break
+
+	assert_eq_deep(result.parameters, [ 1.0, "test", true, 2.0 ])
 
 
 func test_file_path_without_extension():

--- a/test/test_lexer.gd
+++ b/test/test_lexer.gd
@@ -1010,6 +1010,61 @@ func test_variables_assignment_after_line():
 	])
 
 
+func test_events_trigger():
+	var lexer = Lexer.new()
+	var tokens = lexer.init("""
+{ trigger event_name }
+{ trigger event_name, event_name_2 }
+{ trigger event_name(param_1, "text", 1, true) }
+{ trigger event_name(param_1 + 1) }
+""").get_all()
+	assert_eq_deep(tokens, [
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 1, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 1, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_KEYWORD_TRIGGER, "line": 1, "column": 2, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'event_name', "line": 1, "column": 10, },
+		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 1, "column": 21, "value": null, },
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 1, "column": 22, "value": null, },
+
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 2, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 2, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_KEYWORD_TRIGGER, "line": 2, "column": 2, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'event_name', "line": 2, "column": 10, },
+		{ "token": Lexer.TOKEN_COMMA, "line": 2, "column": 20, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'event_name_2', "line": 2, "column": 22, },
+		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 2, "column": 35, "value": null, },
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 2, "column": 36, "value": null, },
+
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 3, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 3, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_KEYWORD_TRIGGER, "line": 3, "column": 2, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'event_name', "line": 3, "column": 10, },
+		{ "token": Lexer.TOKEN_BRACKET_OPEN, "line": 3, "column": 20, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'param_1', "line": 3, "column": 21, },
+		{ "token": Lexer.TOKEN_COMMA, "line": 3, "column": 28, "value": null, },
+		{ "token": Lexer.TOKEN_STRING_LITERAL, "value": 'text', "line": 3, "column": 30, },
+		{ "token": Lexer.TOKEN_COMMA, "line": 3, "column": 36, "value": null, },
+		{ "token": Lexer.TOKEN_NUMBER_LITERAL, "value": '1', "line": 3, "column": 38, },
+		{ "token": Lexer.TOKEN_COMMA, "line": 3, "column": 39, "value": null, },
+		{ "token": Lexer.TOKEN_BOOLEAN_LITERAL, "value": 'true', "line": 3, "column": 41, },
+		{ "token": Lexer.TOKEN_BRACKET_CLOSE, "line": 3, "column": 45, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 3, "column": 47, "value": null, },
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 3, "column": 48, "value": null, },
+
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 4, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_OPEN, "line": 4, "column": 0, "value": null, },
+		{ "token": Lexer.TOKEN_KEYWORD_TRIGGER, "line": 4, "column": 2, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'event_name', "line": 4, "column": 10, },
+		{ "token": Lexer.TOKEN_BRACKET_OPEN, "line": 4, "column": 20, "value": null, },
+		{ "token": Lexer.TOKEN_IDENTIFIER, "value": 'param_1', "line": 4, "column": 21, },
+		{ "token": Lexer.TOKEN_PLUS, "line": 4, "column": 29, "value": null, },
+		{ "token": Lexer.TOKEN_NUMBER_LITERAL, "value": '1', "line": 4, "column": 31, },
+		{ "token": Lexer.TOKEN_BRACKET_CLOSE, "line": 4, "column": 32, "value": null, },
+		{ "token": Lexer.TOKEN_BRACE_CLOSE, "line": 4, "column": 34, "value": null, },
+		{ "token": Lexer.TOKEN_LINE_BREAK, "line": 4, "column": 35, "value": null, },
+		{ "token": Lexer.TOKEN_EOF, "line": 5, "column": 0, "value": null, },
+	])
+
 func test_includes_line_break_when_just_after_or_before_a_logic_block():
 	var lexer = Lexer.new()
 	var tokens = lexer.init("""
@@ -1131,11 +1186,11 @@ func test_imports():
 		{ "token": Lexer.TOKEN_LINK_FILE, "value": { "name": "common", "path": "./to_import"}, "line": 2, "column": 0, },
 		{ "token": Lexer.TOKEN_LINK_FILE, "value": { "name": "common2", "path": "to_import"}, "line": 3, "column": 0, },
 		{ "token": Lexer.TOKEN_LINK_FILE, "value": { "name": "common3", "path": "res://test/dialogue_samples/to_import.clyde"}, "line": 4, "column": 0, },
-		
+
 		{ "token": Lexer.TOKEN_DIVERT, "value": { "link": "common", "block": "some_block_name" }, "line": 6, "column": 0, },
 		{ "token": Lexer.TOKEN_LINE_BREAK, "value": null, "line": 6, "column": 26, },
 		{ "token": Lexer.TOKEN_DIVERT, "value": { "link": "common", "block": "" }, "line": 7, "column": 0, },
 		{ "token": Lexer.TOKEN_LINE_BREAK, "value": null, "line": 7, "column": 10, },
-		
+
 		{ "token": Lexer.TOKEN_EOF, "line": 8, "column": 0, "value": null, },
 	])

--- a/test/test_parser_logic.gd
+++ b/test/test_parser_logic.gd
@@ -943,6 +943,39 @@ func test_trigger_event():
 	}])
 	assert_eq_deep(result, expected)
 
+func test_trigger_event_with_parameters():
+	var result = parse("{ trigger some_event(this_is_a_var, this_is_a_var + 1, 123, 'text', false) } trigger")
+	var expected = _create_doc_payload([{
+		"type": 'action_content',
+		"action": {
+			"type": 'events',
+			"events": [
+				{
+					"type": 'event',
+					"name": 'some_event',
+					"params": [
+						{ "type": 'variable', "name": 'this_is_a_var' },
+						{
+							"type": 'expression',
+							"name": 'add',
+							"elements": [
+								{ "type": 'variable', "name": 'this_is_a_var', },
+								{ "type": 'literal', "name": 'number', "value": 1.0 },
+							],
+						},
+						{ "type": 'literal', "name": 'number', "value": 123.0 },
+						{ "type": 'literal', "name": 'string', "value": "text" },
+						{ "type": 'literal', "name": 'boolean', "value": false },
+					]
+				}
+			],
+		},
+		"content": {
+			"type": 'line',
+			"value": 'trigger', "speaker": null, "id": null, "tags": [], "id_suffixes": null,
+		},
+	}])
+	assert_eq_deep(result, expected)
 
 func test_trigger_multiple_events_in_one_block():
 	var result = parse("{ trigger some_event, another_event } trigger")


### PR DESCRIPTION
Allow passing parameters to events, as defined in the language spec 3.2.0
```
-- you can pass literal arguments
{ trigger my_event("some text", 1, true) }

-- you can pass variables
{ trigger my_event(this_is_a_variable) }

-- and even expressions
{ trigger my_event(some_important_count + something_else) }
```