### PR TITLE
Fix comment shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Integer numbers were being interpolated with the decimal part (e.g. 5 was 5.0)
+- Comment shortcut (default ctrl + k) was being triggered twice, effectively not working
 
 
 ## 6.0.0 (2024-11-26)

--- a/addons/clyde/editor/editor/dialogue_editor.gd
+++ b/addons/clyde/editor/editor/dialogue_editor.gd
@@ -87,10 +87,6 @@ func _load_shortcuts():
 			"handler": _toggle_comment,
 		},
 		{
-			"shortcut": shortcuts.get_shortcut_for_command(Shortcuts.CMD_EDITOR_TOGGLE_COMMENT),
-			"handler": _toggle_comment,
-		},
-		{
 			"shortcut": shortcuts.get_shortcut_for_command(Shortcuts.CMD_EDITOR_FONT_SIZE_UP),
 			"handler": _font_size_up,
 		},

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -498,10 +498,10 @@ func test_external_variables_assignments():
 	)
 
 	assert_eq_deep(interpreter.get_content().type, 'end')
-	wait_frames(5) # wait a few frames to ensure callback was triggered
-	assert_eq(interpreter.get_variable("var"), 2)
+	wait_process_frames(5) # wait a few frames to ensure callback was triggered
+	assert_eq(interpreter.get_variable("var"), 2.0)
 	assert_eq(assignment.var, "var")
-	assert_eq(assignment.value, 1)
+	assert_eq(assignment.value, 1.0)
 
 
 func test_external_variables_interpolation():


### PR DESCRIPTION
Comment shortcut (default ctrl + k) was being triggered twice, effectively not working

Also fixing some test warnings