### PR TITLE
Change dialogue option "name" and "label" to "text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 - Support to `match` conditions makes `match` a reserved keyword inside logic blocks.
+- Dialogue Option `name` and `label` changed to `text`. Only impacts interpreter. No need to re-import.
 
 ### Added
 
@@ -16,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Updated GUT (test harness)
+- Dialogue Option `name` and `label` are now named `text`
 
 ### Fixed
 

--- a/addons/clyde/editor/player/dialogue_bubble.gd
+++ b/addons/clyde/editor/player/dialogue_bubble.gd
@@ -36,10 +36,10 @@ func _configure_line(content: Dictionary, should_show_meta: bool):
 
 
 func _configure_options(content: Dictionary, should_show_meta: bool):
-	if content.name == null:
+	if content.text == null:
 		_content_field.hide()
 	else:
-		_content_field.text = content.name
+		_content_field.text = content.text
 
 	_set_speaker(content)
 	_set_meta(content)
@@ -50,7 +50,7 @@ func _configure_options(content: Dictionary, should_show_meta: bool):
 		var option = content.options[index]
 
 		var do = DialogueOption.instantiate()
-		do.text = "%s. %s" % [index + 1, option.label]
+		do.text = "%s. %s" % [index + 1, option.text]
 		_options_container.add_child(do)
 		do.pressed.connect(_on_option_selected.bind(index))
 

--- a/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.tscn
+++ b/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://dl7sti8x4yl7m" path="res://addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.gd" id="1_tjmj8"]
 [ext_resource type="Script" uid="uid://dg1mab6gcc4qj" path="res://addons/clyde/examples/examples_with_helpers/floating_bubble/clyde_dialogue_config.gd" id="2_bouif"]
 [ext_resource type="PackedScene" uid="uid://c2aifp4pq54ut" path="res://addons/clyde/helpers/bubbles/dialogue_bubble_floating.tscn" id="3_8rmxq"]
-[ext_resource type="Texture2D" uid="uid://cl82ufpwosg48" path="res://icon.png" id="4_iuwpv"]
+[ext_resource type="Texture2D" uid="uid://d05r8uu5a8oru" path="res://icon.png" id="4_iuwpv"]
 
 [node name="example_floating_with_helpers" type="MarginContainer"]
 anchors_preset = 15

--- a/addons/clyde/examples/simple_example/example.gd
+++ b/addons/clyde/examples/simple_example/example.gd
@@ -49,14 +49,14 @@ func _set_up_options(options):
 	for c in _options_container.get_node("items").get_children():
 		c.queue_free()
 
-	_options_container.get_node("name").text = options.get('name') if options.get('name') != null else ''
+	_options_container.get_node("name").text = options.get('text') if options.get('text') != null else ''
 	_options_container.get_node("speaker").text = options.get('speaker') if options.get('speaker') != null else ''
 	_options_container.get_node("speaker").visible = _options_container.get_node("speaker").text != ""
 
 	var index = 0
 	for option in options.options:
 		var btn = Button.new()
-		btn.text = option.label
+		btn.text = option.text
 		btn.connect("button_down",Callable(self,"_on_option_selected").bind(index))
 		_options_container.get_node("items").add_child(btn)
 		index += 1

--- a/addons/clyde/helpers/bubbles/dialogue_bubble.gd
+++ b/addons/clyde/helpers/bubbles/dialogue_bubble.gd
@@ -132,7 +132,7 @@ func _setup_options(content: Dictionary):
 	_fallback_option = null
 	for option in content.options:
 		var i: Button = DialogueOption.instantiate()
-		i.text = option.label
+		i.text = option.text
 		i.button_group = button_group
 		i.pressed.connect(_on_option_pressed.bind(i))
 		_options_container.add_child(i)
@@ -140,7 +140,7 @@ func _setup_options(content: Dictionary):
 			if option.tags.has("fallback"):
 				_fallback_option  = i
 
-	var content_name = content.get("name")
+	var content_name = content.get("text")
 	if content_name == null or content_name.strip_edges().is_empty():
 		_text_field.hide()
 	else:

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -239,7 +239,7 @@ func _handle_options_node(options_node):
 		"speaker": options_node.get("speaker"),
 		"id": options_node.get("id"),
 		"tags": options_node.get("tags"),
-		"name": _replace_variables(_translate_text(options_node.get("id"), options_node.get("name"), options_node.get("id_suffixes"))),
+		"text": _replace_variables(_translate_text(options_node.get("id"), options_node.get("name"), options_node.get("id_suffixes"))),
 		"options": options.map(func(e): return _map_option(e, options.find(e), _config.include_hidden_options)),
 	}
 	if options_node.has("meta"):
@@ -287,7 +287,7 @@ func _map_option(option, _index, include_visibility_prop = false):
 		"speaker": o.get("speaker"),
 		"id": o.get("id"),
 		"tags": o.get("tags"),
-		"label": _replace_variables(_translate_text(o.get("id"), o.get("name"), o.get("id_suffixes"))),
+		"text": _replace_variables(_translate_text(o.get("id"), o.get("name"), o.get("id_suffixes"))),
 	}
 
 	if include_visibility_prop:

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -20,7 +20,7 @@ func _line(line):
 func _options(options):
 	return {
 		"type": "options",
-		"name": options.get("name"),
+		"text": options.get("text"),
 		"id": options.get("id"),
 		"tags": options.get("tags", []),
 		"speaker": options.get("speaker"),
@@ -30,7 +30,7 @@ func _options(options):
 
 func _option(option):
 	return {
-		"label": option.get("label"),
+		"text": option.get("text"),
 		"speaker": option.get("speaker"),
 		"id": option.get("id"),
 		"tags": option.get("tags", [])
@@ -162,14 +162,14 @@ first topics $abc&suffix1
 	interpreter.set_variable("suffix1", "P");
 	interpreter.set_variable("suffix2", "S");
 	var first_options = interpreter.get_content();
-	assert_eq(first_options.name, "simple key with suffix 1")
-	assert_eq(first_options.options[0].label, "simple key with only suffix 2")
+	assert_eq(first_options.text, "simple key with suffix 1")
+	assert_eq(first_options.options[0].text, "simple key with only suffix 2")
 
 	interpreter.choose(0);
 	interpreter.get_content()
 
 	var second_options = interpreter.get_content();
-	assert_eq(second_options.options[0].label, "simple key with suffix 1 and 2")
+	assert_eq(second_options.options[0].text, "simple key with suffix 1 and 2")
 
 
 func test_interpreter_option_id_lookup_suffix():
@@ -190,7 +190,7 @@ func test_options():
 
 	var first_part = [
 		_line({ "type": "line", "text": "what do you want to talk about?", "speaker": "npc" }),
-		_options({ "options": [_option({ "label": "Life" }), _option({ "label": "The universe" }), _option({ "label": "Everything else...", "tags": ["some_tag"] })] }),
+		_options({ "options": [_option({ "text": "Life" }), _option({ "text": "The universe" }), _option({ "text": "Everything else...", "tags": ["some_tag"] })] }),
 		]
 
 	var life_option = [
@@ -212,7 +212,7 @@ func test_fallback_options():
 	var content = parse("*= a\n>= b\nend")
 	interpreter.init(content)
 
-	assert_eq_deep(interpreter.get_content(), _options({ "options": [_option({ "label": "a" }), _option({ "label": "b" }) ] }))
+	assert_eq_deep(interpreter.get_content(), _options({ "options": [_option({ "text": "a" }), _option({ "text": "b" }) ] }))
 	interpreter.choose(0)
 	assert_eq_deep(interpreter.get_content().text, "a")
 	assert_eq_deep(interpreter.get_content().text, "end")
@@ -236,8 +236,8 @@ func test_include_hidden_options():
 	assert_eq_deep(
 		options.options,
 		[
-			_option_with_visibility_prop({ "label": "a", "is_visible": false }),
-			_option_with_visibility_prop({ "label": "b", "is_visible": true })
+			_option_with_visibility_prop({ "text": "a", "is_visible": false }),
+			_option_with_visibility_prop({ "text": "b", "is_visible": true })
 		]
 	)
 
@@ -256,28 +256,28 @@ func test_blocks_and_diverts():
 
 	var initial_dialogue = [
 		_line({ "type": "line", "text": "what do you want to talk about?", "speaker": "npc" }),
-		_options({ "options": [_option({ "label": "Life" }),_option({ "label": "The universe" }), _option({ "label": "Everything else..." }), _option({ "label": "Goodbye!" })] }),
+		_options({ "options": [_option({ "text": "Life" }),_option({ "text": "The universe" }), _option({ "text": "Everything else..." }), _option({ "text": "Goodbye!" })] }),
 	]
 
 	var life_option = [
 		_line({ "type": "line", "text": "I want to talk about life!", "speaker": "player" }),
 		_line({ "type": "line", "text": "Well! That's too complicated...", "speaker": "npc" }),
 		# back to initial dialogue
-		_options({ "options": [_option({ "label": "The universe" }), _option({ "label": "Everything else..." }), _option({ "label": "Goodbye!" })] })
+		_options({ "options": [_option({ "text": "The universe" }), _option({ "text": "Everything else..." }), _option({ "text": "Goodbye!" })] })
 	]
 
 	var everything_option = [
 		_line({ "type": "line", "text": "What about everything else?", "speaker": "player" }),
 		_line({ "type": "line", "text": "I don't have time for this...", "speaker": "npc" }),
 		# back to initial dialogue
-		_options({ "options": [_option({ "label": "The universe" }), _option({ "label": "Goodbye!" })] })
+		_options({ "options": [_option({ "text": "The universe" }), _option({ "text": "Goodbye!" })] })
 	]
 
 	var universe_option = [
 		_line({ "type": "line", "text": "I want to talk about the universe!", "speaker": "player" }),
 		_line({ "type": "line", "text": "That's too complex!", "speaker": "npc" }),
 		# back to initial dialogue
-		_options({ "options": [_option({ "label": "Goodbye!" })] })
+		_options({ "options": [_option({ "text": "Goodbye!" })] })
 	]
 
 	var goodbye_option = [
@@ -463,7 +463,7 @@ func test_variables():
 	assert_eq_deep(dialogue.get_content().text, "hey {you}")
 	assert_eq_deep(
 		dialogue.get_content(),
-		_options({ "options": [_option({ "label": "Life" }), _option({ "label": "The universe" })] })
+		_options({ "options": [_option({ "text": "Life" }), _option({ "text": "The universe" })] })
 	)
 	dialogue.choose(1)
 
@@ -622,8 +622,8 @@ func test_changing_block_order_does_not_affect_persistence():
 	var block_2_options = interpreter.get_content()
 
 
-	assert_eq_deep(block_1_options, _options({ "options": [_option({ "label": "option 2" })] }))
-	assert_eq_deep(block_2_options, _options({ "options": [_option({ "label": "option 1" }), _option({ "label": "option 2" })] }))
+	assert_eq_deep(block_1_options, _options({ "options": [_option({ "text": "option 2" })] }))
+	assert_eq_deep(block_2_options, _options({ "options": [_option({ "text": "option 1" }), _option({ "text": "option 2" })] }))
 
 
 func test_events():
@@ -749,9 +749,9 @@ second option
 
 	var first_line = _line({ "type": "line", "text": "first line" })
 	first_line.meta = { "line": 1, "column": 0 }
-	var first_option = _options({ "options": [_option({"label": "first option"})] })
+	var first_option = _options({ "options": [_option({"text": "first option"})] })
 	first_option.meta = { "line": 2, "column": 0 }
-	var second_option = _options({ "name": "second option", "options": [_option({"label": "option"})] })
+	var second_option = _options({ "text": "second option", "options": [_option({"text": "option"})] })
 	second_option.meta = { "line": 3, "column": 0 }
 
 	assert_eq_deep(interpreter.get_content(), first_line)


### PR DESCRIPTION
This is to make it consistent with the dialogue line.

Usually I'd go through the intermediate deprecation version, but given there is no much usage and a small lift to fix, I'm removing it straight away to avoid confusion and keep things clean.