### PR TITLE
Added visited property to option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added UID files
 - Support to `match` condition blocks
+- Options now have a "visited" property to indicate if they were accessed before
 
 ### Changed
 

--- a/addons/clyde/editor/player/dialogue_bubble.gd
+++ b/addons/clyde/editor/player/dialogue_bubble.gd
@@ -53,6 +53,8 @@ func _configure_options(content: Dictionary, should_show_meta: bool):
 		do.text = "%s. %s" % [index + 1, option.text]
 		_options_container.add_child(do)
 		do.pressed.connect(_on_option_selected.bind(index))
+		if option.visited:
+			do.modulate.a = 0.7
 
 
 func _set_speaker(content: Dictionary):

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -288,6 +288,7 @@ func _map_option(option, _index, include_visibility_prop = false):
 		"id": o.get("id"),
 		"tags": o.get("tags"),
 		"text": _replace_variables(_translate_text(o.get("id"), o.get("name"), o.get("id_suffixes"))),
+		"visited": _mem.was_already_accessed(option._index),
 	}
 
 	if include_visibility_prop:

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -33,7 +33,8 @@ func _option(option):
 		"text": option.get("text"),
 		"speaker": option.get("speaker"),
 		"id": option.get("id"),
-		"tags": option.get("tags", [])
+		"tags": option.get("tags", []),
+		"visited": option.get("visited", false),
 	}
 
 
@@ -247,6 +248,35 @@ func test_include_hidden_options():
 
 	interpreter.choose(1)
 	assert_eq(interpreter.get_content().text, "line b")
+
+
+func test_option_include_visited_information():
+	var interpreter = ClydeDialogue.Interpreter.new()
+	var content = parse("""
++ a
+  line a
+  <-
++ b
+  line b
+  <-
+""")
+	interpreter.init(content)
+
+	# get options
+	interpreter.get_content()
+	# choose first
+	interpreter.choose(0)
+	interpreter.get_content()
+
+	var options = interpreter.get_content()
+
+	assert_eq_deep(
+		options.options,
+		[
+			_option({ "text": "a", "visited": true }),
+			_option({ "text": "b", "visited": false })
+		]
+	)
 
 
 func test_blocks_and_diverts():


### PR DESCRIPTION
This option can be used to format visited sticky options differently. For example, fading out options already "used":

<img width="537" height="240" alt="Example of options with visited option on a slightly faded color" src="https://github.com/user-attachments/assets/49e70b04-2a58-4947-a3b3-da0275a4d0d7" />
