### PR TITLE
Fix startup warnings when helpers are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Integer numbers were being interpolated with the decimal part (e.g. 5 was 5.0)
 - Comment shortcut (default ctrl + k) was being triggered twice, effectively not working
 - Docs URLs
+- Helpers error warnings when installing the plugin for the first time
 
 
 ## 6.0.0 (2024-11-26)

--- a/addons/clyde/examples/examples_with_helpers/fixed_bubble/example_fixed_with_helpers.gd
+++ b/addons/clyde/examples/examples_with_helpers/fixed_bubble/example_fixed_with_helpers.gd
@@ -1,5 +1,7 @@
 extends MarginContainer
 
+# NOTE This example requires the helpers option to be enabled in Project Settings.
+
 @onready var _dialogue_start_button := $VBoxContainer/Button
 @onready var _dialogue_selector := $VBoxContainer/OptionButton
 
@@ -13,7 +15,12 @@ var _dialogue_files = [
 
 var _current_dialogue = 0
 
-# NOTE This example requires the helpers option to be enabled in Project Settings.
+# NOTE: This Dialogue overwrite is only required for these examples to prevent
+# startup errors when the Dialogue helper is not enabled.
+# Feel free to remove this line if you have the helpers enabled
+@onready
+var Dialogue = get_tree().root.get_node("Dialogue") if get_tree().root.has_node("Dialogue") else {}
+
 func _ready():
 	_setup_dialogue_events()
 	_load_buttons()

--- a/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.gd
+++ b/addons/clyde/examples/examples_with_helpers/floating_bubble/example_floating_with_helpers.gd
@@ -1,10 +1,18 @@
 extends MarginContainer
 
+# NOTE This example requires the helpers option to be enabled in Project Settings.
+
 @onready var _dialogue_start_button := $Button
 
 var _is_dialogue_running := false
 
-# NOTE This example requires the helpers option to be enabled in Project Settings.
+
+# NOTE: This Dialogue overwrite is only required for these examples to prevent
+# startup errors when the Dialogue helper is not enabled.
+# Feel free to remove this line if you have the helpers enabled
+@onready
+var Dialogue = get_tree().root.get_node("Dialogue") if get_tree().root.has_node("Dialogue") else {}
+
 
 func _ready():
 	_setup_dialogue_events()

--- a/addons/clyde/helpers/dialogue_config.gd
+++ b/addons/clyde/helpers/dialogue_config.gd
@@ -27,7 +27,9 @@ extends Node
 
 
 func _ready():
-	Dialogue.config = self
+	# Accessing the autoload this way to prevent startup warnings when helpers are disabled
+	if get_tree().root.has_node("Dialogue"):
+		get_tree().root.get_node("Dialogue").config = self
 
 
 func load_data(dialogue_path: String, block_name: String) -> Dictionary:


### PR DESCRIPTION
When the plugin is first installed, it throws a few errors due to the helper singleton not being registered.

Working around singleton imports to prevent warnings