### PR TITLE
Fix dialogue event bubble warning

### DIFF
--- a/addons/clyde/editor/player/dialogue_event_bubble.gd
+++ b/addons/clyde/editor/player/dialogue_event_bubble.gd
@@ -6,10 +6,9 @@ extends VBoxContainer
 
 
 func _setup_color():
-	var current_style = $PanelContainer.get_theme_stylebox("panel")
+	var color = EditorInterface.get_editor_settings().get_setting("interface/theme/accent_color")
 	var style = StyleBoxFlat.new()
-	var color = current_style.get_bg_color().darkened(0.1)
-	color.a = 0.8
+	color.a = 0.1
 	style.set_bg_color(color)
 	style.set_corner_radius_all(5)
 	$PanelContainer.add_theme_stylebox_override("panel", style)

--- a/default_env.tres
+++ b/default_env.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Environment" load_steps=2 format=3 uid="uid://x00024mks4ds"]
+[gd_resource type="Environment" format=3 uid="uid://x00024mks4ds"]
 
 [sub_resource type="Sky" id="1"]
 

--- a/project.godot
+++ b/project.godot
@@ -8,15 +8,19 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="clyde-plugin"
-config/features=PackedStringArray("4.4")
+config/features=PackedStringArray("4.6")
 config/icon="res://icon.png"
 
 [autoload]
 
-Dialogue="*res://addons/clyde/helpers/dialogue_manager.gd"
+Dialogue="*uid://com7sq4jrg1n2"
 
 [dialogue]
 


### PR DESCRIPTION
Fix #72 

In Godot 4.6 the default panel style was changed to `StyleBoxEmpty`, which does not have bg color info. Changing the event bubble to use the accent colour config instead of adapting the default style.