### PR TITLE
Allow clyde to load clyde files outside of res://

### DIFF
--- a/addons/clyde/resource/ClydeDialogueResourceLoader.gd
+++ b/addons/clyde/resource/ClydeDialogueResourceLoader.gd
@@ -1,5 +1,6 @@
 @tool
 class_name ClydeDialogueResourceLoader extends ResourceFormatLoader
+const Parser = preload("../parser/Parser.gd")
 
 func _get_recognized_extensions() -> PackedStringArray:
 	return PackedStringArray(["clyde", "res"])
@@ -17,4 +18,11 @@ func _handles_type(type: StringName) -> bool:
 
 
 func _load(path, original_path, use_sub_threads, cache_mode):
+	if !path.begins_with("res://"):
+		var file = FileAccess.open(path, FileAccess.READ)
+		var clyde = file.get_as_text()
+		var container = ClydeDialogueFile.new()
+		var parser = Parser.new()
+		container.content = parser.parse(clyde)
+		return container
 	return ResourceLoader.load(path)


### PR DESCRIPTION
Allows clyde to load resources from any absolute path on the file system - not just the resources folder.

Currently if your clyde dialoge files are not bundled inside the game as resources, clyde will fail to parse them