### PR TITLE
Expose mode in option content dictionary

### DIFF
--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -289,6 +289,7 @@ func _map_option(option, _index, include_visibility_prop = false):
 		"tags": o.get("tags"),
 		"text": _replace_variables(_translate_text(o.get("id"), o.get("name"), o.get("id_suffixes"))),
 		"visited": _mem.was_already_accessed(option._index),
+		"mode": o.get("mode"),
 	}
 
 	if include_visibility_prop:

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -278,7 +278,7 @@ func test_option_include_visited_information():
 		]
 	)
 	
-func test_option_include_visited_information():
+func test_option_include_mode():
 	var interpreter = ClydeDialogue.Interpreter.new()
 	var content = parse("""
 + a

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -277,6 +277,38 @@ func test_option_include_visited_information():
 			_option({ "text": "b", "visited": false })
 		]
 	)
+	
+func test_option_include_visited_information():
+	var interpreter = ClydeDialogue.Interpreter.new()
+	var content = parse("""
++ a
+  line a
+  <-
+* b
+  line b
+  <-
+> c
+  line c
+  <-
+""")
+	interpreter.init(content)
+
+	# get options
+	interpreter.get_content()
+	# choose first
+	interpreter.choose(0)
+	interpreter.get_content()
+
+	var options = interpreter.get_content()
+
+	assert_eq_deep(
+		options.options,
+		[
+			_option({ "text": "a", "mode": "sticky" }),
+			_option({ "text": "b", "mode": "once" }),
+			_option({ "text": "c", "mode": "fallback" }),
+		]
+	)
 
 
 func test_blocks_and_diverts():


### PR DESCRIPTION
I wanted to render sticky options differently from once options so that the player had some insight into whether they would be able to come back and repeat this dialogue. The underlying logic already existed, I just exposed it in the option's content dictionary and added an appropriate unit test.