### PR TITLE
Option grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Godot-specific ignores
 .godot
 .import/
-*/*.import
+**/*.import
 output/
 export.cfg
 export_presets.cfg

--- a/addons/clyde/editor/editor/clyde_syntax_highlighter.gd
+++ b/addons/clyde/editor/editor/clyde_syntax_highlighter.gd
@@ -9,7 +9,7 @@ var _cache = {}
 
 const _logic_english_operators = [ "and", "or", "not", "is", "isnt" ]
 const _logic_operators_and_symbols = [ "=", "*", "/", "+", "-", "?", ",", "<", ">", "|", "%", "&" ]
-const _logic_keywords = [ "set", "when", "trigger", "match", "default" ]
+const _logic_keywords = [ "set", "when", "trigger", "match", "default", "group" ]
 const _options = [ "*", "+", ">" ]
 
 var _escapable_chars_regex = RegEx.create_from_string("[\\\\|\\*\\+\\>\\%\\(\\)\\{\\}\\\"\\'\\$\\#\\:]")

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -288,8 +288,17 @@ func _prepare_option(option, index, should_include_hidden = false, is_visible = 
 	return option
 
 
+func _get_recursive_option_groups(option):
+	var groups: Array = []
+	var opt_iter = option
+	while opt_iter.has('action'):
+		if opt_iter.action.type == 'option_groups':
+			groups += opt_iter.action.groups
+		opt_iter = opt_iter.get('content')
+	return groups
+
+
 func _check_if_option_valid(option):
-	print_debug("checking option %s" % str(option))
 	if option == null:
 		return false
 	
@@ -298,22 +307,14 @@ func _check_if_option_valid(option):
 	if _mem.was_already_accessed(option._index):
 		return option.mode != 'once'
 	
+	var groups = _get_recursive_option_groups(option)
+	
 	# options with no groups are valid
-	if option.get('action') == null \
-			or option.action.type != 'option_groups' \
-			or (option.action.type == 'option_groups' and option.action.groups.size() == 0):
+	if groups.size() == 0:
 		return true
 	
-	# all that remains is unchosen grouped options
-	# these are valid if and only if none of their groups have been chosen
-	var groups =  option.action.groups
-	print_debug(groups)
-	var map = groups.map(func(group): return group["id"])
-	#var any = map.any(_mem.group_was_already_chosen)
-	#print_debug("\tgroups %s\r\n" % str(groups) \
-	#	+ "\tmap %s\r\n" % str(map) \
-	#	+ "\tany %s" % str(any))
-	return not option.action.groups.map(func(group): return group.id).any(_mem.group_was_already_chosen)
+	# unchosen grouped options are valid iff none of their groups have been chose
+	return not groups.map(func(grp): return grp.id).any(_mem.group_was_already_chosen)
 
 func _map_option(option, _index, include_visibility_prop = false):
 	var o = option
@@ -353,7 +354,8 @@ func _handle_action(action_node):
 	if action_node.action.type == 'events':
 		_trigger_events(action_node.action)
 	elif action_node.action.type == 'option_groups':
-		_set_groups_as_chosen(action_node.action)
+		var groups = _get_recursive_option_groups(action_node)
+		_set_groups_as_chosen(groups)
 	else:
 		for assignment in action_node.action.assignments:
 			_logic.handle_assignment(assignment)
@@ -370,7 +372,7 @@ func _trigger_events(events):
 
 
 func _set_groups_as_chosen(groups):
-	for group in groups.groups:
+	for group in groups:
 		_mem.set_group_as_accessed(group.id)
 
 

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -154,6 +154,15 @@ func _generate_index() -> String:
 	return "%s_%s" % [_stack_head().current._index, _stack_head().content_index]
 
 
+func _get_from_content(content, key):
+	if content.has(key):
+		return content[key]
+	elif !content.has("content"):
+		return null
+	else:
+		return _get_from_content(content.content, key)
+
+
 func _initialize_handlers() -> void:
 	_handlers = {
 		"document": _handle_document_node,
@@ -222,6 +231,7 @@ func _handle_options_node(options_node):
 	_add_to_stack(options_node)
 
 	var options = _get_visible_options(options_node.content)
+	print_debug("FINAL OPTIONS LIST: " + str(options))
 
 	_mem.set_internal_variable('OPTIONS_COUNT', options.size())
 
@@ -250,24 +260,25 @@ func _handle_options_node(options_node):
 func _get_visible_options(options):
 	return options.map(func (e):
 		return _prepare_option(e, options.find(e), _config.include_hidden_options)
-	).filter(_check_if_option_not_accessed)
+	).filter(_check_if_option_valid)
 
 
 func _prepare_option(option, index, should_include_hidden = false, is_visible = true):
+	print_debug("Option: %s (%s)\r\n%s" % [_get_from_content(option, "name"), option.type, str(option)])
 	if option.get("index") == null:
 		option._index = "%s_%s" % [_generate_index(), index]
 
 	if option.type == 'conditional_content':
 		option.content._index = option._index;
 
-		var is_visible_option = !!_logic.check_condition(option.conditions)
+		var is_visible_option = _logic.check_condition(option.conditions)
 		if should_include_hidden or is_visible_option:
 			return _prepare_option(option.content, index, should_include_hidden, is_visible_option)
 		return null
 
 	if option.type == 'action_content':
 		option.content._index = option._index
-		option.mode = option.content.mode
+		option.mode = _get_from_content(option, "mode")
 		var content = _prepare_option(option.content, index, should_include_hidden)
 		if content == null:
 			return null
@@ -277,12 +288,39 @@ func _prepare_option(option, index, should_include_hidden = false, is_visible = 
 	return option
 
 
-func _check_if_option_not_accessed(option):
-	return option != null and not (option.mode == 'once' and _mem.was_already_accessed(option._index))
-
+func _check_if_option_valid(option):
+	print_debug("checking option %s" % str(option))
+	if option == null:
+		return false
+	
+	# already-chosen "once" options are not valid
+	# other already-chosen options are valid regardless of groups
+	if _mem.was_already_accessed(option._index):
+		return option.mode != 'once'
+	
+	# options with no groups are valid
+	if option.get('action') == null \
+			or option.action.type != 'option_groups' \
+			or (option.action.type == 'option_groups' and option.action.groups.size() == 0):
+		return true
+	
+	# all that remains is unchosen grouped options
+	# these are valid if and only if none of their groups have been chosen
+	var groups =  option.action.groups
+	print_debug(groups)
+	var map = groups.map(func(group): return group["id"])
+	#var any = map.any(_mem.group_was_already_chosen)
+	#print_debug("\tgroups %s\r\n" % str(groups) \
+	#	+ "\tmap %s\r\n" % str(map) \
+	#	+ "\tany %s" % str(any))
+	return not option.action.groups.map(func(group): return group.id).any(_mem.group_was_already_chosen)
 
 func _map_option(option, _index, include_visibility_prop = false):
-	var o = option if option.type == 'option' else option.content
+	var o = option
+	while o.type != 'option':
+		if !o.has('content'):
+			break
+		o = o.content
 	var result = {
 		"speaker": o.get("speaker"),
 		"id": o.get("id"),
@@ -314,6 +352,8 @@ func _handle_action_content_node(action_node):
 func _handle_action(action_node):
 	if action_node.action.type == 'events':
 		_trigger_events(action_node.action)
+	elif action_node.action.type == 'option_groups':
+		_set_groups_as_chosen(action_node.action)
 	else:
 		for assignment in action_node.action.assignments:
 			_logic.handle_assignment(assignment)
@@ -327,6 +367,11 @@ func _trigger_events(events):
 			parameters = event.params.map(_logic.get_node_value)
 
 		event_triggered.emit(event.name, parameters)
+
+
+func _set_groups_as_chosen(groups):
+	for group in groups.groups:
+		_mem.set_group_as_accessed(group.id)
 
 
 func _handle_conditional_content_node(conditional_node, fallback_node = _stack_head().current):

--- a/addons/clyde/interpreter/Interpreter.gd
+++ b/addons/clyde/interpreter/Interpreter.gd
@@ -289,6 +289,7 @@ func _map_option(option, _index, include_visibility_prop = false):
 		"tags": o.get("tags"),
 		"text": _replace_variables(_translate_text(o.get("id"), o.get("name"), o.get("id_suffixes"))),
 		"visited": _mem.was_already_accessed(option._index),
+		"mode": o.get("mode"),
 	}
 
 	if include_visibility_prop:

--- a/addons/clyde/interpreter/Memory.gd
+++ b/addons/clyde/interpreter/Memory.gd
@@ -9,6 +9,7 @@ var _mem = {
 	"variables": {},
 	"internal": {},
 	"e_variables": {},
+	"option_groups": {},
 }
 
 var _external_variable_prefix = "@"
@@ -21,6 +22,15 @@ func set_as_accessed(id):
 
 func was_already_accessed(id):
 	return _mem.access.has(str(id))
+
+
+func set_group_as_accessed(group_id):
+	_mem.option_groups[str(group_id)] = true
+	print_debug(_mem)
+
+
+func group_was_already_chosen(id):
+	return _mem.option_groups.has(str(id))
 
 
 func set_variable(id: String, value: Variant) -> Variant:
@@ -81,6 +91,7 @@ func get_all() -> Dictionary:
 		"access": _mem.access,
 		"variables": _mem.variables,
 		"internal": _mem.internal,
+		"option_groups": _mem.option_groups,
 	}
 
 
@@ -95,6 +106,7 @@ func clear() -> void:
 		"variables": {},
 		"internal": {},
 		"e_variables": {},
+		"option_groups": {},
 	}
 
 

--- a/addons/clyde/parser/Lexer.gd
+++ b/addons/clyde/parser/Lexer.gd
@@ -44,6 +44,7 @@ const TOKEN_KEYWORD_TRIGGER = "trigger"
 const TOKEN_KEYWORD_WHEN = "when"
 const TOKEN_KEYWORD_MATCH = "match"
 const TOKEN_KEYWORD_DEFAULT = "default"
+const TOKEN_KEYWORD_GROUP = "group"
 const TOKEN_ASSIGN = "="
 const TOKEN_ASSIGN_SUM = "+="
 const TOKEN_ASSIGN_SUB = "-="
@@ -99,7 +100,7 @@ const _token_hints = {
 
 const _keywords = [
 	'is', 'isnt', 'or', 'and', 'not', 'true', 'false', 'null',
-	'set', 'trigger', 'when', 'match',
+	'set', 'trigger', 'when', 'match', 'group',
 ]
 
 var _input = ""
@@ -863,6 +864,8 @@ func _handle_logic_descpritive_operator(value, initial_column):
 			return Token(TOKEN_KEYWORD_TRIGGER, _line, initial_column)
 		'when':
 			return Token(TOKEN_KEYWORD_WHEN, _line, initial_column)
+		'group':
+			return Token(TOKEN_KEYWORD_GROUP, _line, initial_column)
 
 
 func _handle_logic_not():

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -904,7 +904,7 @@ func ConditionalContentNode(conditions, content = null):
 
 func ActionContentNode(action, content = null):
 	return { "type": 'action_content', "action": action, "content": content }
-
+	
 
 func ExpressionNode(name, elements):
 	return { "type": 'expression', "name": name, "elements": elements }

--- a/addons/clyde/parser/Parser.gd
+++ b/addons/clyde/parser/Parser.gd
@@ -567,6 +567,10 @@ func _logic_block():
 	if _tokens.has_next([Lexer.TOKEN_KEYWORD_TRIGGER]):
 		var events = _events()
 		return ActionContentNode(events)
+	
+	if _tokens.has_next([Lexer.TOKEN_KEYWORD_GROUP]):
+		var option_groups = _option_groups()
+		return ActionContentNode(option_groups)
 
 	if _tokens.has_next([Lexer.TOKEN_KEYWORD_WHEN]):
 		_tokens.consume([Lexer.TOKEN_KEYWORD_WHEN])
@@ -600,7 +604,6 @@ func _events():
 
 	return EventsNode(events)
 
-
 func _event(event_name: String):
 	if not _tokens.has_next([Lexer.TOKEN_BRACKET_OPEN]):
 		return EventNode(event_name)
@@ -616,6 +619,22 @@ func _event(event_name: String):
 
 	return EventNode(event_name, params)
 
+func _option_groups():
+	_tokens.consume([Lexer.TOKEN_KEYWORD_GROUP])
+	_tokens.consume([Lexer.TOKEN_IDENTIFIER])
+	var groups = [_option_group(_tokens.current_token.value)]
+	
+	while _tokens.has_next([Lexer.TOKEN_COMMA]):
+		_tokens.consume([Lexer.TOKEN_COMMA])
+		_tokens.consume([Lexer.TOKEN_IDENTIFIER])
+		groups.push_back(_option_group(_tokens.current_token.value))
+	
+	_tokens.consume([Lexer.TOKEN_BRACE_CLOSE])
+	
+	return OptionGroupsNode(groups)
+
+func _option_group(group_id):
+	return OptionGroupNode(group_id)
 
 func _conditional_line():
 	var expression = _condition()
@@ -907,6 +926,14 @@ func EventNode(name, parameters = null):
 	if parameters == null or parameters.size() == 0:
 		return { "type": 'event', "name": name }
 	return { "type": 'event', "name": name, "params": parameters }
+
+
+func OptionGroupsNode(groups):
+	return { "type": 'option_groups', "groups": groups }
+
+
+func OptionGroupNode(id):
+	return { "type": 'option_group', "id": id }
 
 
 func MatchBlockNode(condition, branches, defeault_branch):

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -278,7 +278,7 @@ func test_option_include_visited_information():
 		]
 	)
 	
-func test_option_include_visited_information():
+func test_option_include_mode():
 	var interpreter = ClydeDialogue.Interpreter.new()
 	var content = parse("""
 + a

--- a/test/test_interpreter.gd
+++ b/test/test_interpreter.gd
@@ -277,6 +277,38 @@ func test_option_include_visited_information():
 			_option({ "text": "b", "visited": false })
 		]
 	)
+	
+func test_option_include_visited_information():
+	var interpreter = ClydeDialogue.Interpreter.new()
+	var content = parse("""
++ a
+  line a
+  <-
+* b
+  line b
+  <-
+> c
+  line c
+  <-
+""")
+	interpreter.init(content)
+
+	# get options
+	interpreter.get_content()
+	# choose first
+	interpreter.choose(0)
+	interpreter.get_content()
+
+	var options = interpreter.get_content()
+
+	assert_eq_deep(
+		options.options,
+		[
+			_option({ "text": "a", "mode": "sticky" }),
+			_option({ "text": "b", "mode": "once" }),
+			_option({ "text": "c", "mode": "fallback" }),
+		]
+	)
 
 
 func test_blocks_and_diverts():


### PR DESCRIPTION
1. Added group to Lexer as a block type that can be defined on an option.
2. Added group nodes to Parser as Action nodes.
3. Memory now tracks which groups have been selected.
4. Interpreter will no longer display options whose groups have already been selected (except for the originally-selected option itself if it is sticky or fallback).